### PR TITLE
Upgrade vscode-css-languageservice to v5.1.8 and related code

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -44,17 +44,17 @@ Coc has support for all features that [vscode-css-languageservice](https://www.n
 
 - **css.trace.server**:
 
-  default: `"off"`
+  Traces the communication between VS Code and the CSS language server, default: `"off"`
 
   Valid options: ["off","messages","verbose"]
 
 - **css.customData**:
 
-  default: `[]`
+  A list of relative file paths pointing to JSON files following the [custom data format](https://github.com/microsoft/vscode-css-languageservice/blob/master/docs/customData.md). coc.nvim loads custom data on startup to enhance its CSS support for the custom CSS properties, at directives, pseudo classes and pseudo elements you specify in the JSON files. The file paths are relative to workspace and only workspace folder settings are considered, default: `[]`
 
 - **css.completion.triggerPropertyValueCompletion**:
 
-  By default, coc.nvim triggers property value completion after selecting a CSS property. Use this setting to disable this behavior., default: `true`
+  By default, coc.nvim triggers property value completion after selecting a CSS property. Use this setting to disable this behavior, default: `true`
 
 - **css.completion.completePropertyWithSemicolon**:
 
@@ -62,7 +62,15 @@ Coc has support for all features that [vscode-css-languageservice](https://www.n
 
 - **css.validate**:
 
-  default: `true`
+  Controls SCSS validation and problem severities, default: `true`
+
+- **css.hover.documentation**:
+
+  Show tag and attribute documentation in SCSS hovers, default: `true`
+
+- **css.hover.references**:
+
+  Show references to MDN in SCSS hovers, default: `true`
 
 - **css.colorDecorators.enable**:
 
@@ -94,31 +102,31 @@ Coc has support for all features that [vscode-css-languageservice](https://www.n
 
 - **css.lint.importStatement**:
 
-  Avoid using !important. It is an indication that the specificity of the entire CSS has gotten out of control and needs to be refactored., default: `"ignore"`
+  Avoid using !important. It is an indication that the specificity of the entire CSS has gotten out of control and needs to be refactored, default: `"ignore"`
 
   Valid options: ["ignore","warning","error"]
 
 - **css.lint.boxModel**:
 
-  default: `"ignore"`
+  Do not use `width` or `height` when using `padding` or `border`, default: `"ignore"`
 
   Valid options: ["ignore","warning","error"]
 
 - **css.lint.universalSelector**:
 
-  The universal selector (\*) is known to be slow, default: `"ignore"`
+  The universal selector (`*`) is known to be slow, default: `"ignore"`
 
   Valid options: ["ignore","warning","error"]
 
 - **css.lint.zeroUnits**:
 
-  default: `"ignore"`
+  No unit for zero needed, default: `"ignore"`
 
   Valid options: ["ignore","warning","error"]
 
 - **css.lint.fontFaceProperties**:
 
-  @font-face rule must define 'src' and 'font-family' properties, default: `"warning"`
+  `@font-face` rule must define `src` and `font-family` properties, default: `"warning"`
 
   Valid options: ["ignore","warning","error"]
 
@@ -136,55 +144,201 @@ Coc has support for all features that [vscode-css-languageservice](https://www.n
 
 - **css.lint.unknownProperties**:
 
-  Unknown property., default: `"warning"`
+  Unknown property, default: `"warning"`
 
   Valid options: ["ignore","warning","error"]
 
+- **css.lint.validProperties**:
+
+  A list of properties that are not validated against the `unknownProperties` rule, default: `[]`
+
 - **css.lint.ieHack**:
 
-  default: `"ignore"`
+  IE hacks are only necessary when supporting IE7 and older, default: `"ignore"`
 
   Valid options: ["ignore","warning","error"]
 
 - **css.lint.unknownVendorSpecificProperties**:
 
-  Unknown vendor specific property., default: `"ignore"`
+  Unknown vendor specific property, default: `"ignore"`
 
   Valid options: ["ignore","warning","error"]
 
 - **css.lint.propertyIgnoredDueToDisplay**:
 
-  Property is ignored due to the display. E.g. with 'display: inline', the width, height, margin-top, margin-bottom, and float properties have no effect, default: `"warning"`
+  Property is ignored due to the display. E.g. with `display: inline`, the `width`, `height`, `margin-top`, `margin-bottom`, and `float` properties have no effect, default: `"warning"`
 
   Valid options: ["ignore","warning","error"]
 
 - **css.lint.important**:
 
-  Import statements do not load in parallel, default: `"ignore"`
+  Avoid using `!important`. It is an indication that the specificity of the entire CSS has gotten out of control and needs to be refactored, default: `"ignore"`
 
   Valid options: ["ignore","warning","error"]
 
 - **css.lint.float**:
 
-  Avoid using 'float'. Floats lead to fragile CSS that is easy to break if one aspect of the layout changes., default: `"ignore"`
+  Avoid using `float`. Floats lead to fragile CSS that is easy to break if one aspect of the layout changes, default: `"ignore"`
 
   Valid options: ["ignore","warning","error"]
 
 - **css.lint.idSelector**:
 
-  Selectors should not contain IDs because these rules are too tightly coupled with the HTML., default: `"ignore"`
+  Selectors should not contain IDs because these rules are too tightly coupled with the HTML, default: `"ignore"`
 
   Valid options: ["ignore","warning","error"]
 
 - **css.lint.unknownAtRules**:
 
-  Unknown at-rule., default: `"warning"`
+  Unknown at-rule, default: `"warning"`
+
+  Valid options: ["ignore","warning","error"]
+
+- **scss.completion.triggerPropertyValueCompletion**:
+
+  By default, coc.nvim triggers property value completion after selecting a CSS property. Use this setting to disable this behavior, default: `true`
+
+- **scss.completion.completePropertyWithSemicolon**:
+
+  Insert semicolon at end of line when completing CSS properties, default: `true`
+
+- **scss.validate**:
+
+  Controls SCSS validation and problem severities, default: `true`
+
+- **scss.colorDecorators.enable**:
+
+  default: `true`
+
+- **scss.hover.documentation**:
+
+  Show tag and attribute documentation in SCSS hovers, default: `true`
+
+- **scss.hover.references**:
+
+  Show references to MDN in SCSS hovers, default: `true`
+
+- **scss.lint.compatibleVendorPrefixes**:
+
+  When using a vendor-specific prefix make sure to also include all other vendor-specific properties, default: `"ignore"`
+
+  Valid options: ["ignore","warning","error"]
+
+- **scss.lint.vendorPrefix**:
+
+  When using a vendor-specific prefix, also include the standard property, default: `"warning"`
+
+  Valid options: ["ignore","warning","error"]
+
+- **scss.lint.duplicateProperties**:
+
+  Do not use duplicate style definitions, default: `"ignore"`
+
+  Valid options: ["ignore","warning","error"]
+
+- **scss.lint.emptyRules**:
+
+  Do not use empty rulesets, default: `"warning"`
+
+  Valid options: ["ignore","warning","error"]
+
+- **scss.lint.importStatement**:
+
+  Import statements do not load in parallel, default: `"ignore"`
+
+  Valid options: ["ignore","warning","error"]
+
+- **scss.lint.boxModel**:
+
+  Do not use `width` or `height` when using `padding` or `border`, default: `"ignore"`
+
+  Valid options: ["ignore","warning","error"]
+
+- **scss.lint.universalSelector**:
+
+  The universal selector (`*`) is known to be slow, default: `"ignore"`
+
+  Valid options: ["ignore","warning","error"]
+
+- **scss.lint.zeroUnits**:
+
+  No unit for zero needed, default: `"ignore"`
+
+  Valid options: ["ignore","warning","error"]
+
+- **scss.lint.fontFaceProperties**:
+
+  `@font-face` rule must define `src` and `font-family` properties, default: `"warning"`
+
+  Valid options: ["ignore","warning","error"]
+
+- **scss.lint.hexColorLength**:
+
+  Hex colors must consist of three or six hex numbers, default: `"error"`
+
+  Valid options: ["ignore","warning","error"]
+
+- **scss.lint.argumentsInColorFunction**:
+
+  Invalid number of parameters, default: `"error"`
+
+  Valid options: ["ignore","warning","error"]
+
+- **scss.lint.unknownProperties**:
+
+  Unknown property, default: `"warning"`
+
+  Valid options: ["ignore","warning","error"]
+
+- **scss.lint.validProperties**:
+
+  A list of properties that are not validated against the `unknownProperties` rule, default: `[]`
+
+- **scss.lint.ieHack**:
+
+  IE hacks are only necessary when supporting IE7 and older, default: `"ignore"`
+
+  Valid options: ["ignore","warning","error"]
+
+- **scss.lint.unknownVendorSpecificProperties**:
+
+  Unknown vendor specific property, default: `"ignore"`
+
+  Valid options: ["ignore","warning","error"]
+
+- **scss.lint.propertyIgnoredDueToDisplay**:
+
+  Property is ignored due to the display. E.g. with `display: inline`, the `width`, `height`, `margin-top`, `margin-bottom`, and `float` properties have no effect, default: `"warning"`
+
+  Valid options: ["ignore","warning","error"]
+
+- **scss.lint.important**:
+
+  Avoid using `!important`. It is an indication that the specificity of the entire CSS has gotten out of control and needs to be refactored, default: `"ignore"`
+
+  Valid options: ["ignore","warning","error"]
+
+- **scss.lint.float**:
+
+  Avoid using `float`. Floats lead to fragile CSS that is easy to break if one aspect of the layout changes, default: `"ignore"`
+
+  Valid options: ["ignore","warning","error"]
+
+- **scss.lint.idSelector**:
+
+  Selectors should not contain IDs because these rules are too tightly coupled with the HTML, default: `"ignore"`
+
+  Valid options: ["ignore","warning","error"]
+
+- **scss.lint.unknownAtRules**:
+
+  Unknown at-rule, default: `"ignore"`
 
   Valid options: ["ignore","warning","error"]
 
 - **less.completion.triggerPropertyValueCompletion**:
 
-  By default, coc.nvim triggers property value completion after selecting a CSS property. Use this setting to disable this behavior., default: `true`
+  By default, coc.nvim triggers property value completion after selecting a CSS property. Use this setting to disable this behavior, default: `true`
 
 - **less.completion.completePropertyWithSemicolon**:
 
@@ -192,11 +346,19 @@ Coc has support for all features that [vscode-css-languageservice](https://www.n
 
 - **less.validate**:
 
-  default: `true`
+  Enables or disables all validations, default: `true`
 
 - **less.colorDecorators.enable**:
 
   default: `true`
+
+- **less.hover.documentation**:
+
+  Show tag and attribute documentation in LESS hovers, default: `true`
+
+- **less.hover.references**:
+
+  Show references to MDN in LESS hovers, default: `true`
 
 - **less.lint.compatibleVendorPrefixes**:
 
@@ -224,13 +386,13 @@ Coc has support for all features that [vscode-css-languageservice](https://www.n
 
 - **less.lint.importStatement**:
 
-  Avoid using !important. It is an indication that the specificity of the entire CSS has gotten out of control and needs to be refactored., default: `"ignore"`
+  Avoid using !important. It is an indication that the specificity of the entire CSS has gotten out of control and needs to be refactored, default: `"ignore"`
 
   Valid options: ["ignore","warning","error"]
 
 - **less.lint.boxModel**:
 
-  default: `"ignore"`
+  Do not use `width` or `height` when using `padding` or `border`, default: `"ignore"`
 
   Valid options: ["ignore","warning","error"]
 
@@ -242,13 +404,13 @@ Coc has support for all features that [vscode-css-languageservice](https://www.n
 
 - **less.lint.zeroUnits**:
 
-  default: `"ignore"`
+  No unit for zero needed, default: `"ignore"`
 
   Valid options: ["ignore","warning","error"]
 
 - **less.lint.fontFaceProperties**:
 
-  @font-face rule must define 'src' and 'font-family' properties, default: `"warning"`
+  `@font-face` rule must define `src` and `font-family` properties, default: `"warning"`
 
   Valid options: ["ignore","warning","error"]
 
@@ -266,173 +428,53 @@ Coc has support for all features that [vscode-css-languageservice](https://www.n
 
 - **less.lint.unknownProperties**:
 
-  Unknown property., default: `"warning"`
+  Unknown property, default: `"warning"`
 
   Valid options: ["ignore","warning","error"]
+
+- **less.lint.validProperties**:
+
+  A list of properties that are not validated against the `unknownProperties` rule, default: `[]`
 
 - **less.lint.ieHack**:
-
-  default: `"ignore"`
-
-  Valid options: ["ignore","warning","error"]
-
-- **less.lint.unknownVendorSpecificProperties**:
-
-  Unknown vendor specific property., default: `"ignore"`
-
-  Valid options: ["ignore","warning","error"]
-
-- **less.lint.propertyIgnoredDueToDisplay**:
-
-  Property is ignored due to the display. E.g. with 'display: inline', the width, height, margin-top, margin-bottom, and float properties have no effect, default: `"warning"`
-
-  Valid options: ["ignore","warning","error"]
-
-- **less.lint.important**:
-
-  Import statements do not load in parallel, default: `"ignore"`
-
-  Valid options: ["ignore","warning","error"]
-
-- **less.lint.float**:
-
-  Avoid using 'float'. Floats lead to fragile CSS that is easy to break if one aspect of the layout changes., default: `"ignore"`
-
-  Valid options: ["ignore","warning","error"]
-
-- **less.lint.idSelector**:
-
-  Selectors should not contain IDs because these rules are too tightly coupled with the HTML., default: `"ignore"`
-
-  Valid options: ["ignore","warning","error"]
-
-- **less.lint.unknownAtRules**:
-
-  Unknown at-rule., default: `"warning"`
-
-  Valid options: ["ignore","warning","error"]
-
-- **scss.completion.triggerPropertyValueCompletion**:
-
-  By default, coc.nvim triggers property value completion after selecting a CSS property. Use this setting to disable this behavior., default: `true`
-
-- **scss.completion.completePropertyWithSemicolon**:
-
-  Insert semicolon at end of line when completing CSS properties, default: `true`
-
-- **scss.validate**:
-
-  default: `true`
-
-- **scss.colorDecorators.enable**:
-
-  default: `true`
-
-- **scss.lint.compatibleVendorPrefixes**:
-
-  default: `"ignore"`
-
-  Valid options: ["ignore","warning","error"]
-
-- **scss.lint.vendorPrefix**:
-
-  default: `"warning"`
-
-  Valid options: ["ignore","warning","error"]
-
-- **scss.lint.duplicateProperties**:
-
-  default: `"ignore"`
-
-  Valid options: ["ignore","warning","error"]
-
-- **scss.lint.emptyRules**:
-
-  default: `"warning"`
-
-  Valid options: ["ignore","warning","error"]
-
-- **scss.lint.importStatement**:
-
-  default: `"ignore"`
-
-  Valid options: ["ignore","warning","error"]
-
-- **scss.lint.boxModel**:
-
-  Do not use width or height when using padding or border, default: `"ignore"`
-
-  Valid options: ["ignore","warning","error"]
-
-- **scss.lint.universalSelector**:
-
-  default: `"ignore"`
-
-  Valid options: ["ignore","warning","error"]
-
-- **scss.lint.zeroUnits**:
-
-  default: `"ignore"`
-
-  Valid options: ["ignore","warning","error"]
-
-- **scss.lint.fontFaceProperties**:
-
-  default: `"warning"`
-
-  Valid options: ["ignore","warning","error"]
-
-- **scss.lint.hexColorLength**:
-
-  default: `"error"`
-
-  Valid options: ["ignore","warning","error"]
-
-- **scss.lint.argumentsInColorFunction**:
-
-  default: `"error"`
-
-  Valid options: ["ignore","warning","error"]
-
-- **scss.lint.unknownProperties**:
-
-  default: `"warning"`
-
-  Valid options: ["ignore","warning","error"]
-
-- **scss.lint.ieHack**:
 
   IE hacks are only necessary when supporting IE7 and older, default: `"ignore"`
 
   Valid options: ["ignore","warning","error"]
 
-- **scss.lint.unknownVendorSpecificProperties**:
+- **less.lint.unknownVendorSpecificProperties**:
 
-  default: `"ignore"`
-
-  Valid options: ["ignore","warning","error"]
-
-- **scss.lint.propertyIgnoredDueToDisplay**:
-
-  default: `"warning"`
+  Unknown vendor specific property, default: `"ignore"`
 
   Valid options: ["ignore","warning","error"]
 
-- **scss.lint.important**:
+- **less.lint.propertyIgnoredDueToDisplay**:
 
-  default: `"ignore"`
-
-  Valid options: ["ignore","warning","error"]
-
-- **scss.lint.float**:
-
-  default: `"ignore"`
+  Property is ignored due to the display. E.g. with `display: inline`, the `width`, `height`, `margin-top`, `margin-bottom`, and `float` properties have no effect, default: `"warning"`
 
   Valid options: ["ignore","warning","error"]
 
-- **scss.lint.idSelector**:
+- **less.lint.important**:
 
-  default: `"ignore"`
+  Avoid using `!important`. It is an indication that the specificity of the entire CSS has gotten out of control and needs to be refactored, default: `"ignore"`
+
+  Valid options: ["ignore","warning","error"]
+
+- **less.lint.float**:
+
+  Avoid using `float`. Floats lead to fragile CSS that is easy to break if one aspect of the layout changes, default: `"ignore"`
+
+  Valid options: ["ignore","warning","error"]
+
+- **less.lint.idSelector**:
+
+  Selectors should not contain IDs because these rules are too tightly coupled with the HTML, default: `"ignore"`
+
+  Valid options: ["ignore","warning","error"]
+
+- **less.lint.unknownAtRules**:
+
+  Unknown at-rule, default: `"warning"`
 
   Valid options: ["ignore","warning","error"]
 

--- a/package.json
+++ b/package.json
@@ -33,16 +33,18 @@
         },
         "css.trace.server": {
           "type": "string",
-          "default": "off",
+          "scope": "window",
           "enum": [
             "off",
             "messages",
             "verbose"
-          ]
+          ],
+          "default": "off",
+          "description": "Traces the communication between VS Code and the CSS language server"
         },
         "css.customData": {
           "type": "array",
-          "markdownDescription": "A list of relative file paths pointing to JSON files following the [custom data format](https://github.com/Microsoft/vscode-css-languageservice/blob/master/docs/customData.md).\n\ncoc.nvim loads custom data on startup to enhance its CSS support for the custom CSS properties, at directives, pseudo classes and pseudo elements you specify in the JSON files.\n\nThe file paths are relative to workspace and only workspace folder settings are considered.",
+          "markdownDescription": "A list of relative file paths pointing to JSON files following the [custom data format](https://github.com/microsoft/vscode-css-languageservice/blob/master/docs/customData.md).\n\ncoc.nvim loads custom data on startup to enhance its CSS support for the custom CSS properties, at directives, pseudo classes and pseudo elements you specify in the JSON files.\n\nThe file paths are relative to workspace and only workspace folder settings are considered",
           "default": [],
           "items": {
             "type": "string"
@@ -53,7 +55,7 @@
           "type": "boolean",
           "scope": "resource",
           "default": true,
-          "description": "By default, coc.nvim triggers property value completion after selecting a CSS property. Use this setting to disable this behavior."
+          "description": "By default, coc.nvim triggers property value completion after selecting a CSS property. Use this setting to disable this behavior"
         },
         "css.completion.completePropertyWithSemicolon": {
           "type": "boolean",
@@ -64,12 +66,25 @@
         "css.validate": {
           "type": "boolean",
           "scope": "resource",
-          "default": true
+          "default": true,
+          "description": "Controls SCSS validation and problem severities"
         },
         "css.colorDecorators.enable": {
           "type": "boolean",
           "scope": "window",
           "default": true
+        },
+        "css.hover.documentation": {
+          "type": "boolean",
+          "scope": "resource",
+          "default": true,
+          "description": "Show tag and attribute documentation in SCSS hovers"
+        },
+        "css.hover.references": {
+          "type": "boolean",
+          "scope": "resource",
+          "default": true,
+          "description": "Show references to MDN in SCSS hovers"
         },
         "css.lint.compatibleVendorPrefixes": {
           "type": "string",
@@ -91,7 +106,7 @@
             "error"
           ],
           "default": "warning",
-          "description": "When using a vendor-specific prefix also include the standard property"
+          "description": "When using a vendor-specific prefix, also include the standard property"
         },
         "css.lint.duplicateProperties": {
           "type": "string",
@@ -124,7 +139,7 @@
             "error"
           ],
           "default": "ignore",
-          "description": "Avoid using !important. It is an indication that the specificity of the entire CSS has gotten out of control and needs to be refactored."
+          "description": "Import statements do not load in parallel"
         },
         "css.lint.boxModel": {
           "type": "string",
@@ -134,7 +149,8 @@
             "warning",
             "error"
           ],
-          "default": "ignore"
+          "default": "ignore",
+          "markdownDescription": "Do not use `width` or `height` when using `padding` or `border`"
         },
         "css.lint.universalSelector": {
           "type": "string",
@@ -145,7 +161,7 @@
             "error"
           ],
           "default": "ignore",
-          "description": "The universal selector (*) is known to be slow"
+          "markdownDescription": "The universal selector (`*`) is known to be slow"
         },
         "css.lint.zeroUnits": {
           "type": "string",
@@ -155,7 +171,8 @@
             "warning",
             "error"
           ],
-          "default": "ignore"
+          "default": "ignore",
+          "description": "No unit for zero needed"
         },
         "css.lint.fontFaceProperties": {
           "type": "string",
@@ -166,7 +183,7 @@
             "error"
           ],
           "default": "warning",
-          "description": "@font-face rule must define 'src' and 'font-family' properties"
+          "markdownDescription": "`@font-face` rule must define `src` and `font-family` properties"
         },
         "css.lint.hexColorLength": {
           "type": "string",
@@ -199,7 +216,17 @@
             "error"
           ],
           "default": "warning",
-          "description": "Unknown property."
+          "description": "Unknown property"
+        },
+        "css.lint.validProperties": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "scope": "resource",
+          "default": [],
+          "description": "A list of properties that are not validated against the `unknownProperties` rule"
         },
         "css.lint.ieHack": {
           "type": "string",
@@ -209,7 +236,8 @@
             "warning",
             "error"
           ],
-          "default": "ignore"
+          "default": "ignore",
+          "description": "IE hacks are only necessary when supporting IE7 and older"
         },
         "css.lint.unknownVendorSpecificProperties": {
           "type": "string",
@@ -220,7 +248,7 @@
             "error"
           ],
           "default": "ignore",
-          "description": "Unknown vendor specific property."
+          "description": "Unknown vendor specific property"
         },
         "css.lint.propertyIgnoredDueToDisplay": {
           "type": "string",
@@ -231,7 +259,7 @@
             "error"
           ],
           "default": "warning",
-          "description": "Property is ignored due to the display. E.g. with 'display: inline', the width, height, margin-top, margin-bottom, and float properties have no effect"
+          "markdownDescription": "Property is ignored due to the display. E.g. with `display: inline`, the `width`, `height`, `margin-top`, `margin-bottom`, and `float` properties have no effect"
         },
         "css.lint.important": {
           "type": "string",
@@ -242,7 +270,7 @@
             "error"
           ],
           "default": "ignore",
-          "description": "Import statements do not load in parallel"
+          "markdownDescription": "Avoid using `!important`. It is an indication that the specificity of the entire CSS has gotten out of control and needs to be refactored"
         },
         "css.lint.float": {
           "type": "string",
@@ -253,7 +281,7 @@
             "error"
           ],
           "default": "ignore",
-          "description": "Avoid using 'float'. Floats lead to fragile CSS that is easy to break if one aspect of the layout changes."
+          "markdownDescription": "Avoid using `float`. Floats lead to fragile CSS that is easy to break if one aspect of the layout changes"
         },
         "css.lint.idSelector": {
           "type": "string",
@@ -264,7 +292,7 @@
             "error"
           ],
           "default": "ignore",
-          "description": "Selectors should not contain IDs because these rules are too tightly coupled with the HTML."
+          "description": "Selectors should not contain IDs because these rules are too tightly coupled with the HTML"
         },
         "css.lint.unknownAtRules": {
           "type": "string",
@@ -275,13 +303,267 @@
             "error"
           ],
           "default": "warning",
-          "description": "Unknown at-rule."
+          "description": "Unknown at-rule"
+        },
+        "scss.completion.triggerPropertyValueCompletion": {
+          "type": "boolean",
+          "scope": "resource",
+          "default": true,
+          "description": "By default, coc.nvim triggers property value completion after selecting a CSS property. Use this setting to disable this behavior"
+        },
+        "scss.completion.completePropertyWithSemicolon": {
+          "type": "boolean",
+          "scope": "resource",
+          "default": true,
+          "description": "Insert semicolon at end of line when completing CSS properties"
+        },
+        "scss.validate": {
+          "type": "boolean",
+          "scope": "resource",
+          "default": true,
+          "description": "Controls SCSS validation and problem severities"
+        },
+        "scss.colorDecorators.enable": {
+          "type": "boolean",
+          "scope": "window",
+          "default": true
+        },
+        "scss.hover.documentation": {
+          "type": "boolean",
+          "scope": "resource",
+          "default": true,
+          "description": "Show tag and attribute documentation in SCSS hovers"
+        },
+        "scss.hover.references": {
+          "type": "boolean",
+          "scope": "resource",
+          "default": true,
+          "description": "Show references to MDN in SCSS hovers"
+        },
+        "scss.lint.compatibleVendorPrefixes": {
+          "type": "string",
+          "scope": "resource",
+          "enum": [
+            "ignore",
+            "warning",
+            "error"
+          ],
+          "default": "ignore",
+          "description": "When using a vendor-specific prefix make sure to also include all other vendor-specific properties"
+        },
+        "scss.lint.vendorPrefix": {
+          "type": "string",
+          "scope": "resource",
+          "enum": [
+            "ignore",
+            "warning",
+            "error"
+          ],
+          "default": "warning",
+          "description": "When using a vendor-specific prefix, also include the standard property"
+        },
+        "scss.lint.duplicateProperties": {
+          "type": "string",
+          "scope": "resource",
+          "enum": [
+            "ignore",
+            "warning",
+            "error"
+          ],
+          "default": "ignore",
+          "description": "Do not use duplicate style definitions"
+        },
+        "scss.lint.emptyRules": {
+          "type": "string",
+          "scope": "resource",
+          "enum": [
+            "ignore",
+            "warning",
+            "error"
+          ],
+          "default": "warning",
+          "description": "Do not use empty rulesets"
+        },
+        "scss.lint.importStatement": {
+          "type": "string",
+          "scope": "resource",
+          "enum": [
+            "ignore",
+            "warning",
+            "error"
+          ],
+          "default": "ignore",
+          "description": "Import statements do not load in parallel"
+        },
+        "scss.lint.boxModel": {
+          "type": "string",
+          "scope": "resource",
+          "enum": [
+            "ignore",
+            "warning",
+            "error"
+          ],
+          "default": "ignore",
+          "markdownDescription": "Do not use `width` or `height` when using `padding` or `border`"
+        },
+        "scss.lint.universalSelector": {
+          "type": "string",
+          "scope": "resource",
+          "enum": [
+            "ignore",
+            "warning",
+            "error"
+          ],
+          "default": "ignore",
+          "markdownDescription": "The universal selector (`*`) is known to be slow"
+        },
+        "scss.lint.zeroUnits": {
+          "type": "string",
+          "scope": "resource",
+          "enum": [
+            "ignore",
+            "warning",
+            "error"
+          ],
+          "default": "ignore",
+          "description": "No unit for zero needed"
+        },
+        "scss.lint.fontFaceProperties": {
+          "type": "string",
+          "scope": "resource",
+          "enum": [
+            "ignore",
+            "warning",
+            "error"
+          ],
+          "default": "warning",
+          "markdownDescription": "`@font-face` rule must define `src` and `font-family` properties"
+        },
+        "scss.lint.hexColorLength": {
+          "type": "string",
+          "scope": "resource",
+          "enum": [
+            "ignore",
+            "warning",
+            "error"
+          ],
+          "default": "error",
+          "description": "Hex colors must consist of three or six hex numbers"
+        },
+        "scss.lint.argumentsInColorFunction": {
+          "type": "string",
+          "scope": "resource",
+          "enum": [
+            "ignore",
+            "warning",
+            "error"
+          ],
+          "default": "error",
+          "description": "Invalid number of parameters"
+        },
+        "scss.lint.unknownProperties": {
+          "type": "string",
+          "scope": "resource",
+          "enum": [
+            "ignore",
+            "warning",
+            "error"
+          ],
+          "default": "warning",
+          "description": "Unknown property"
+        },
+        "scss.lint.validProperties": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "scope": "resource",
+          "default": [],
+          "description": "A list of properties that are not validated against the `unknownProperties` rule"
+        },
+        "scss.lint.ieHack": {
+          "type": "string",
+          "scope": "resource",
+          "enum": [
+            "ignore",
+            "warning",
+            "error"
+          ],
+          "default": "ignore",
+          "description": "IE hacks are only necessary when supporting IE7 and older"
+        },
+        "scss.lint.unknownVendorSpecificProperties": {
+          "type": "string",
+          "scope": "resource",
+          "enum": [
+            "ignore",
+            "warning",
+            "error"
+          ],
+          "default": "ignore",
+          "description": "Unknown vendor specific property"
+        },
+        "scss.lint.propertyIgnoredDueToDisplay": {
+          "type": "string",
+          "scope": "resource",
+          "enum": [
+            "ignore",
+            "warning",
+            "error"
+          ],
+          "default": "warning",
+          "markdownDescription": "Property is ignored due to the display. E.g. with `display: inline`, the `width`, `height`, `margin-top`, `margin-bottom`, and `float` properties have no effect"
+        },
+        "scss.lint.important": {
+          "type": "string",
+          "scope": "resource",
+          "enum": [
+            "ignore",
+            "warning",
+            "error"
+          ],
+          "default": "ignore",
+          "markdownDescription": "Avoid using `!important`. It is an indication that the specificity of the entire CSS has gotten out of control and needs to be refactored"
+        },
+        "scss.lint.float": {
+          "type": "string",
+          "scope": "resource",
+          "enum": [
+            "ignore",
+            "warning",
+            "error"
+          ],
+          "default": "ignore",
+          "markdownDescription": "Avoid using `float`. Floats lead to fragile CSS that is easy to break if one aspect of the layout changes"
+        },
+        "scss.lint.idSelector": {
+          "type": "string",
+          "scope": "resource",
+          "enum": [
+            "ignore",
+            "warning",
+            "error"
+          ],
+          "default": "ignore",
+          "description": "Selectors should not contain IDs because these rules are too tightly coupled with the HTML"
+        },
+        "scss.lint.unknownAtRules": {
+          "type": "string",
+          "scope": "resource",
+          "enum": [
+            "ignore",
+            "warning",
+            "error"
+          ],
+          "default": "warning",
+          "description": "Unknown at-rule"
         },
         "less.completion.triggerPropertyValueCompletion": {
           "type": "boolean",
           "scope": "resource",
           "default": true,
-          "description": "By default, coc.nvim triggers property value completion after selecting a CSS property. Use this setting to disable this behavior."
+          "description": "By default, coc.nvim triggers property value completion after selecting a CSS property. Use this setting to disable this behavior"
         },
         "less.completion.completePropertyWithSemicolon": {
           "type": "boolean",
@@ -292,12 +574,25 @@
         "less.validate": {
           "type": "boolean",
           "scope": "resource",
-          "default": true
+          "default": true,
+          "description": "Enables or disables all validations"
         },
         "less.colorDecorators.enable": {
           "type": "boolean",
           "scope": "window",
           "default": true
+        },
+        "less.hover.documentation": {
+          "type": "boolean",
+          "scope": "resource",
+          "default": true,
+          "description": "Show tag and attribute documentation in LESS hovers"
+        },
+        "less.hover.references": {
+          "type": "boolean",
+          "scope": "resource",
+          "default": true,
+          "description": "Show references to MDN in LESS hovers"
         },
         "less.lint.compatibleVendorPrefixes": {
           "type": "string",
@@ -352,7 +647,7 @@
             "error"
           ],
           "default": "ignore",
-          "description": "Avoid using !important. It is an indication that the specificity of the entire CSS has gotten out of control and needs to be refactored."
+          "description": "Avoid using !important. It is an indication that the specificity of the entire CSS has gotten out of control and needs to be refactored"
         },
         "less.lint.boxModel": {
           "type": "string",
@@ -362,7 +657,8 @@
             "warning",
             "error"
           ],
-          "default": "ignore"
+          "default": "ignore",
+          "markdownDescription": "Do not use `width` or `height` when using `padding` or `border`"
         },
         "less.lint.universalSelector": {
           "type": "string",
@@ -373,7 +669,7 @@
             "error"
           ],
           "default": "ignore",
-          "description": "The universal selector (*) is known to be slow"
+          "markdownDescription": "The universal selector (`*`) is known to be slow"
         },
         "less.lint.zeroUnits": {
           "type": "string",
@@ -383,7 +679,8 @@
             "warning",
             "error"
           ],
-          "default": "ignore"
+          "default": "ignore",
+          "description": "No unit for zero needed"
         },
         "less.lint.fontFaceProperties": {
           "type": "string",
@@ -394,7 +691,7 @@
             "error"
           ],
           "default": "warning",
-          "description": "@font-face rule must define 'src' and 'font-family' properties"
+          "markdownDescription": "`@font-face` rule must define `src` and `font-family` properties"
         },
         "less.lint.hexColorLength": {
           "type": "string",
@@ -427,228 +724,19 @@
             "error"
           ],
           "default": "warning",
-          "description": "Unknown property."
+          "description": "Unknown property"
+        },
+        "less.lint.validProperties": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "scope": "resource",
+          "default": [],
+          "description": "A list of properties that are not validated against the `unknownProperties` rule"
         },
         "less.lint.ieHack": {
-          "type": "string",
-          "scope": "resource",
-          "enum": [
-            "ignore",
-            "warning",
-            "error"
-          ],
-          "default": "ignore"
-        },
-        "less.lint.unknownVendorSpecificProperties": {
-          "type": "string",
-          "scope": "resource",
-          "enum": [
-            "ignore",
-            "warning",
-            "error"
-          ],
-          "default": "ignore",
-          "description": "Unknown vendor specific property."
-        },
-        "less.lint.propertyIgnoredDueToDisplay": {
-          "type": "string",
-          "scope": "resource",
-          "enum": [
-            "ignore",
-            "warning",
-            "error"
-          ],
-          "default": "warning",
-          "description": "Property is ignored due to the display. E.g. with 'display: inline', the width, height, margin-top, margin-bottom, and float properties have no effect"
-        },
-        "less.lint.important": {
-          "type": "string",
-          "scope": "resource",
-          "enum": [
-            "ignore",
-            "warning",
-            "error"
-          ],
-          "default": "ignore",
-          "description": "Import statements do not load in parallel"
-        },
-        "less.lint.float": {
-          "type": "string",
-          "scope": "resource",
-          "enum": [
-            "ignore",
-            "warning",
-            "error"
-          ],
-          "default": "ignore",
-          "description": "Avoid using 'float'. Floats lead to fragile CSS that is easy to break if one aspect of the layout changes."
-        },
-        "less.lint.idSelector": {
-          "type": "string",
-          "scope": "resource",
-          "enum": [
-            "ignore",
-            "warning",
-            "error"
-          ],
-          "default": "ignore",
-          "description": "Selectors should not contain IDs because these rules are too tightly coupled with the HTML."
-        },
-        "less.lint.unknownAtRules": {
-          "type": "string",
-          "scope": "resource",
-          "enum": [
-            "ignore",
-            "warning",
-            "error"
-          ],
-          "default": "warning",
-          "description": "Unknown at-rule."
-        },
-        "scss.completion.triggerPropertyValueCompletion": {
-          "type": "boolean",
-          "scope": "resource",
-          "default": true,
-          "description": "By default, coc.nvim triggers property value completion after selecting a CSS property. Use this setting to disable this behavior."
-        },
-        "scss.completion.completePropertyWithSemicolon": {
-          "type": "boolean",
-          "scope": "resource",
-          "default": true,
-          "description": "Insert semicolon at end of line when completing CSS properties"
-        },
-        "scss.validate": {
-          "type": "boolean",
-          "scope": "resource",
-          "default": true
-        },
-        "scss.colorDecorators.enable": {
-          "type": "boolean",
-          "scope": "window",
-          "default": true
-        },
-        "scss.lint.compatibleVendorPrefixes": {
-          "type": "string",
-          "scope": "resource",
-          "enum": [
-            "ignore",
-            "warning",
-            "error"
-          ],
-          "default": "ignore"
-        },
-        "scss.lint.vendorPrefix": {
-          "type": "string",
-          "scope": "resource",
-          "enum": [
-            "ignore",
-            "warning",
-            "error"
-          ],
-          "default": "warning"
-        },
-        "scss.lint.duplicateProperties": {
-          "type": "string",
-          "scope": "resource",
-          "enum": [
-            "ignore",
-            "warning",
-            "error"
-          ],
-          "default": "ignore"
-        },
-        "scss.lint.emptyRules": {
-          "type": "string",
-          "scope": "resource",
-          "enum": [
-            "ignore",
-            "warning",
-            "error"
-          ],
-          "default": "warning"
-        },
-        "scss.lint.importStatement": {
-          "type": "string",
-          "scope": "resource",
-          "enum": [
-            "ignore",
-            "warning",
-            "error"
-          ],
-          "default": "ignore"
-        },
-        "scss.lint.boxModel": {
-          "type": "string",
-          "scope": "resource",
-          "enum": [
-            "ignore",
-            "warning",
-            "error"
-          ],
-          "default": "ignore",
-          "description": "Do not use width or height when using padding or border"
-        },
-        "scss.lint.universalSelector": {
-          "type": "string",
-          "scope": "resource",
-          "enum": [
-            "ignore",
-            "warning",
-            "error"
-          ],
-          "default": "ignore"
-        },
-        "scss.lint.zeroUnits": {
-          "type": "string",
-          "scope": "resource",
-          "enum": [
-            "ignore",
-            "warning",
-            "error"
-          ],
-          "default": "ignore"
-        },
-        "scss.lint.fontFaceProperties": {
-          "type": "string",
-          "scope": "resource",
-          "enum": [
-            "ignore",
-            "warning",
-            "error"
-          ],
-          "default": "warning"
-        },
-        "scss.lint.hexColorLength": {
-          "type": "string",
-          "scope": "resource",
-          "enum": [
-            "ignore",
-            "warning",
-            "error"
-          ],
-          "default": "error"
-        },
-        "scss.lint.argumentsInColorFunction": {
-          "type": "string",
-          "scope": "resource",
-          "enum": [
-            "ignore",
-            "warning",
-            "error"
-          ],
-          "default": "error"
-        },
-        "scss.lint.unknownProperties": {
-          "type": "string",
-          "scope": "resource",
-          "enum": [
-            "ignore",
-            "warning",
-            "error"
-          ],
-          "default": "warning"
-        },
-        "scss.lint.ieHack": {
           "type": "string",
           "scope": "resource",
           "enum": [
@@ -659,7 +747,7 @@
           "default": "ignore",
           "description": "IE hacks are only necessary when supporting IE7 and older"
         },
-        "scss.lint.unknownVendorSpecificProperties": {
+        "less.lint.unknownVendorSpecificProperties": {
           "type": "string",
           "scope": "resource",
           "enum": [
@@ -667,9 +755,10 @@
             "warning",
             "error"
           ],
-          "default": "ignore"
+          "default": "ignore",
+          "description": "Unknown vendor specific property"
         },
-        "scss.lint.propertyIgnoredDueToDisplay": {
+        "less.lint.propertyIgnoredDueToDisplay": {
           "type": "string",
           "scope": "resource",
           "enum": [
@@ -677,9 +766,10 @@
             "warning",
             "error"
           ],
-          "default": "warning"
+          "default": "warning",
+          "markdownDescription": "Property is ignored due to the display. E.g. with `display: inline`, the `width`, `height`, `margin-top`, `margin-bottom`, and `float` properties have no effect"
         },
-        "scss.lint.important": {
+        "less.lint.important": {
           "type": "string",
           "scope": "resource",
           "enum": [
@@ -687,9 +777,10 @@
             "warning",
             "error"
           ],
-          "default": "ignore"
+          "default": "ignore",
+          "markdownDescription": "Avoid using `!important`. It is an indication that the specificity of the entire CSS has gotten out of control and needs to be refactored"
         },
-        "scss.lint.float": {
+        "less.lint.float": {
           "type": "string",
           "scope": "resource",
           "enum": [
@@ -697,9 +788,10 @@
             "warning",
             "error"
           ],
-          "default": "ignore"
+          "default": "ignore",
+          "markdownDescription": "Avoid using `float`. Floats lead to fragile CSS that is easy to break if one aspect of the layout changes"
         },
-        "scss.lint.idSelector": {
+        "less.lint.idSelector": {
           "type": "string",
           "scope": "resource",
           "enum": [
@@ -707,7 +799,19 @@
             "warning",
             "error"
           ],
-          "default": "ignore"
+          "default": "ignore",
+          "description": "Selectors should not contain IDs because these rules are too tightly coupled with the HTML"
+        },
+        "less.lint.unknownAtRules": {
+          "type": "string",
+          "scope": "resource",
+          "enum": [
+            "ignore",
+            "warning",
+            "error"
+          ],
+          "default": "warning",
+          "description": "Unknown at-rule"
         },
         "wxss.validate": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -910,9 +910,9 @@
     "rimraf": "^3.0.2",
     "ts-loader": "^8.0.7",
     "typescript": "^4.0.5",
-    "vscode-css-languageservice": "4.3.5",
-    "vscode-languageserver": "7.0.0-next.3",
-    "vscode-uri": "^2.1.2",
+    "vscode-css-languageservice": "5.1.8",
+    "vscode-languageserver": "7.0.0",
+    "vscode-uri": "^3.0.2",
     "webpack": "^5.2.0",
     "webpack-cli": "^4.1.0"
   },

--- a/server/cssServer.ts
+++ b/server/cssServer.ts
@@ -4,370 +4,602 @@
  *--------------------------------------------------------------------------------------------*/
 
 import {
-	Connection, TextDocuments, InitializeParams, InitializeResult, ServerCapabilities, ConfigurationRequest, WorkspaceFolder, TextDocumentSyncKind, NotificationType
-} from 'vscode-languageserver';
-import { URI } from 'vscode-uri';
-import { getCSSLanguageService, getSCSSLanguageService, getLESSLanguageService, LanguageSettings, LanguageService, Stylesheet, TextDocument, Position } from 'vscode-css-languageservice';
-import { getLanguageModelCache } from './languageModelCache';
-import { formatError, runSafeAsync } from './utils/runner';
-import { getDocumentContext } from './utils/documentContext';
-import { fetchDataProviders } from './customData';
-import { RequestService, getRequestService } from './requests';
+  Connection,
+  TextDocuments,
+  InitializeParams,
+  InitializeResult,
+  ServerCapabilities,
+  ConfigurationRequest,
+  WorkspaceFolder,
+  TextDocumentSyncKind,
+  NotificationType,
+  Disposable
+} from 'vscode-languageserver'
+import { URI } from 'vscode-uri'
+import {
+  getCSSLanguageService,
+  getSCSSLanguageService,
+  getLESSLanguageService,
+  LanguageSettings,
+  LanguageService,
+  Stylesheet,
+  TextDocument,
+  Position
+} from 'vscode-css-languageservice'
+import { getLanguageModelCache } from './languageModelCache'
+import { formatError, runSafeAsync } from './utils/runner'
+import { getDocumentContext } from './utils/documentContext'
+import { fetchDataProviders } from './customData'
+import { RequestService, getRequestService } from './requests'
 
 namespace CustomDataChangedNotification {
-	export const type: NotificationType<string[]> = new NotificationType('css/customDataChanged');
+  export const type: NotificationType<string[]> = new NotificationType(
+    'css/customDataChanged'
+  )
 }
 
 export interface Settings {
-	css: LanguageSettings;
-	less: LanguageSettings;
-	scss: LanguageSettings;
+  css: LanguageSettings
+  less: LanguageSettings
+  scss: LanguageSettings
 }
 
 export interface RuntimeEnvironment {
-	file?: RequestService;
-	http?: RequestService
+  readonly file?: RequestService
+  readonly http?: RequestService
+  readonly timer: {
+    setImmediate(callback: (...args: any[]) => void, ...args: any[]): Disposable
+    setTimeout(
+      callback: (...args: any[]) => void,
+      ms: number,
+      ...args: any[]
+    ): Disposable
+  }
 }
 
-export function startServer(connection: Connection, runtime: RuntimeEnvironment) {
+export function startServer(
+  connection: Connection,
+  runtime: RuntimeEnvironment
+) {
+  // Create a text document manager.
+  const documents = new TextDocuments(TextDocument)
+  // Make the text document manager listen on the connection
+  // for open, change and close text document events
+  documents.listen(connection)
 
-	// Create a text document manager.
-	const documents = new TextDocuments(TextDocument);
-	// Make the text document manager listen on the connection
-	// for open, change and close text document events
-	documents.listen(connection);
+  const stylesheets = getLanguageModelCache<Stylesheet>(10, 60, (document) =>
+    getLanguageService(document).parseStylesheet(document)
+  )
+  documents.onDidClose((e) => {
+    stylesheets.onDocumentRemoved(e.document)
+  })
+  connection.onShutdown(() => {
+    stylesheets.dispose()
+  })
 
-	const stylesheets = getLanguageModelCache<Stylesheet>(10, 60, document => getLanguageService(document).parseStylesheet(document));
-	documents.onDidClose(e => {
-		stylesheets.onDocumentRemoved(e.document);
-	});
-	connection.onShutdown(() => {
-		stylesheets.dispose();
-	});
+  let scopedSettingsSupport = false
+  let foldingRangeLimit = Number.MAX_VALUE
+  let workspaceFolders: WorkspaceFolder[]
 
-	let scopedSettingsSupport = false;
-	let foldingRangeLimit = Number.MAX_VALUE;
-	let workspaceFolders: WorkspaceFolder[];
+  let dataProvidersReady: Promise<any> = Promise.resolve()
 
-	let dataProvidersReady: Promise<any> = Promise.resolve();
+  const languageServices: { [id: string]: LanguageService } = {}
 
-	const languageServices: { [id: string]: LanguageService } = {};
+  const notReady = () => Promise.reject('Not Ready')
+  let requestService: RequestService = {
+    getContent: notReady,
+    stat: notReady,
+    readDirectory: notReady
+  }
 
-	const notReady = () => Promise.reject('Not Ready');
-	let requestService: RequestService = { getContent: notReady, stat: notReady, readDirectory: notReady };
+  // After the server has started the client sends an initialize request. The server receives
+  // in the passed params the rootPath of the workspace plus the client capabilities.
+  connection.onInitialize((params: InitializeParams): InitializeResult => {
+    workspaceFolders = (<any>params).workspaceFolders
+    if (!Array.isArray(workspaceFolders)) {
+      workspaceFolders = []
+      if (params.rootPath) {
+        workspaceFolders.push({
+          name: '',
+          uri: URI.file(params.rootPath).toString()
+        })
+      }
+    }
 
-	// After the server has started the client sends an initialize request. The server receives
-	// in the passed params the rootPath of the workspace plus the client capabilities.
-	connection.onInitialize((params: InitializeParams): InitializeResult => {
-		workspaceFolders = (<any>params).workspaceFolders;
-		if (!Array.isArray(workspaceFolders)) {
-			workspaceFolders = [];
-			if (params.rootPath) {
-				workspaceFolders.push({ name: '', uri: URI.file(params.rootPath).toString() });
-			}
-		}
+    requestService = getRequestService(
+      params.initializationOptions?.handledSchemas || ['file'],
+      connection,
+      runtime
+    )
 
-		requestService = getRequestService(params.initializationOptions?.handledSchemas || ['file'], connection, runtime);
+    function getClientCapability<T>(name: string, def: T) {
+      const keys = name.split('.')
+      let c: any = params.capabilities
+      for (let i = 0; c && i < keys.length; i++) {
+        if (!c.hasOwnProperty(keys[i])) {
+          return def
+        }
+        c = c[keys[i]]
+      }
+      return c
+    }
+    const snippetSupport = !!getClientCapability(
+      'textDocument.completion.completionItem.snippetSupport',
+      false
+    )
+    scopedSettingsSupport = !!getClientCapability(
+      'workspace.configuration',
+      false
+    )
+    foldingRangeLimit = getClientCapability(
+      'textDocument.foldingRange.rangeLimit',
+      Number.MAX_VALUE
+    )
 
-		function getClientCapability<T>(name: string, def: T) {
-			const keys = name.split('.');
-			let c: any = params.capabilities;
-			for (let i = 0; c && i < keys.length; i++) {
-				if (!c.hasOwnProperty(keys[i])) {
-					return def;
-				}
-				c = c[keys[i]];
-			}
-			return c;
-		}
-		const snippetSupport = !!getClientCapability('textDocument.completion.completionItem.snippetSupport', false);
-		scopedSettingsSupport = !!getClientCapability('workspace.configuration', false);
-		foldingRangeLimit = getClientCapability('textDocument.foldingRange.rangeLimit', Number.MAX_VALUE);
+    languageServices.css = getCSSLanguageService({
+      fileSystemProvider: requestService,
+      clientCapabilities: params.capabilities
+    })
+    languageServices.scss = getSCSSLanguageService({
+      fileSystemProvider: requestService,
+      clientCapabilities: params.capabilities
+    })
+    languageServices.less = getLESSLanguageService({
+      fileSystemProvider: requestService,
+      clientCapabilities: params.capabilities
+    })
 
-		languageServices.css = getCSSLanguageService({ fileSystemProvider: requestService, clientCapabilities: params.capabilities });
-		languageServices.scss = getSCSSLanguageService({ fileSystemProvider: requestService, clientCapabilities: params.capabilities });
-		languageServices.less = getLESSLanguageService({ fileSystemProvider: requestService, clientCapabilities: params.capabilities });
+    const capabilities: ServerCapabilities = {
+      textDocumentSync: TextDocumentSyncKind.Incremental,
+      completionProvider: snippetSupport
+        ? { resolveProvider: false, triggerCharacters: ['/', '-', ':'] }
+        : undefined,
+      hoverProvider: true,
+      documentSymbolProvider: true,
+      referencesProvider: true,
+      definitionProvider: true,
+      documentHighlightProvider: true,
+      documentLinkProvider: {
+        resolveProvider: false
+      },
+      codeActionProvider: true,
+      renameProvider: true,
+      colorProvider: {},
+      foldingRangeProvider: true,
+      selectionRangeProvider: true
+    }
+    return { capabilities }
+  })
 
-		const capabilities: ServerCapabilities = {
-			textDocumentSync: TextDocumentSyncKind.Incremental,
-			completionProvider: snippetSupport ? { resolveProvider: false, triggerCharacters: ['/', '-'] } : undefined,
-			hoverProvider: true,
-			documentSymbolProvider: true,
-			referencesProvider: true,
-			definitionProvider: true,
-			documentHighlightProvider: true,
-			documentLinkProvider: {
-				resolveProvider: false
-			},
-			codeActionProvider: true,
-			renameProvider: true,
-			colorProvider: {},
-			foldingRangeProvider: true,
-			selectionRangeProvider: true
-		};
-		return { capabilities };
-	});
+  function getLanguageService(document: TextDocument) {
+    let service = languageServices[document.languageId]
+    if (!service) {
+      connection.console.log(
+        'Document type is ' + document.languageId + ', using css instead.'
+      )
+      service = languageServices['css']
+    }
+    return service
+  }
 
-	function getLanguageService(document: TextDocument) {
-		let service = languageServices[document.languageId];
-		if (!service) {
-			connection.console.log('Document type is ' + document.languageId + ', using css instead.');
-			service = languageServices['css'];
-		}
-		return service;
-	}
+  let documentSettings: {
+    [key: string]: Thenable<LanguageSettings | undefined>
+  } = {}
+  // remove document settings on close
+  documents.onDidClose((e) => {
+    delete documentSettings[e.document.uri]
+  })
+  function getDocumentSettings(
+    textDocument: TextDocument
+  ): Thenable<LanguageSettings | undefined> {
+    if (scopedSettingsSupport) {
+      let promise = documentSettings[textDocument.uri]
+      if (!promise) {
+        const configRequestParam = {
+          items: [
+            { scopeUri: textDocument.uri, section: textDocument.languageId }
+          ]
+        }
+        promise = connection
+          .sendRequest(ConfigurationRequest.type, configRequestParam)
+          .then((s) => s[0])
+        documentSettings[textDocument.uri] = promise
+      }
+      return promise
+    }
+    return Promise.resolve(undefined)
+  }
 
-	let documentSettings: { [key: string]: Thenable<LanguageSettings | undefined> } = {};
-	// remove document settings on close
-	documents.onDidClose(e => {
-		delete documentSettings[e.document.uri];
-	});
-	function getDocumentSettings(textDocument: TextDocument): Thenable<LanguageSettings | undefined> {
-		if (scopedSettingsSupport) {
-			let promise = documentSettings[textDocument.uri];
-			if (!promise) {
-				const configRequestParam = { items: [{ scopeUri: textDocument.uri, section: textDocument.languageId }] };
-				promise = connection.sendRequest(ConfigurationRequest.type, configRequestParam).then(s => s[0]);
-				documentSettings[textDocument.uri] = promise;
-			}
-			return promise;
-		}
-		return Promise.resolve(undefined);
-	}
+  // The settings have changed. Is send on server activation as well.
+  connection.onDidChangeConfiguration((change) => {
+    updateConfiguration(<Settings>change.settings)
+  })
 
-	// The settings have changed. Is send on server activation as well.
-	connection.onDidChangeConfiguration(change => {
-		updateConfiguration(<Settings>change.settings);
-	});
+  function updateConfiguration(settings: Settings) {
+    for (const languageId in languageServices) {
+      languageServices[languageId].configure((settings as any)[languageId])
+    }
+    // reset all document settings
+    documentSettings = {}
+    // Revalidate any open text documents
+    documents.all().forEach(triggerValidation)
+  }
 
-	function updateConfiguration(settings: Settings) {
-		for (const languageId in languageServices) {
-			languageServices[languageId].configure((settings as any)[languageId]);
-		}
-		// reset all document settings
-		documentSettings = {};
-		// Revalidate any open text documents
-		documents.all().forEach(triggerValidation);
-	}
+  const pendingValidationRequests: { [uri: string]: Disposable } = {}
+  const validationDelayMs = 500
 
-	const pendingValidationRequests: { [uri: string]: NodeJS.Timer } = {};
-	const validationDelayMs = 500;
+  // The content of a text document has changed. This event is emitted
+  // when the text document first opened or when its content has changed.
+  documents.onDidChangeContent((change) => {
+    triggerValidation(change.document)
+  })
 
-	// The content of a text document has changed. This event is emitted
-	// when the text document first opened or when its content has changed.
-	documents.onDidChangeContent(change => {
-		triggerValidation(change.document);
-	});
+  // a document has closed: clear all diagnostics
+  documents.onDidClose((event) => {
+    cleanPendingValidation(event.document)
+    connection.sendDiagnostics({ uri: event.document.uri, diagnostics: [] })
+  })
 
-	// a document has closed: clear all diagnostics
-	documents.onDidClose(event => {
-		cleanPendingValidation(event.document);
-		connection.sendDiagnostics({ uri: event.document.uri, diagnostics: [] });
-	});
+  function cleanPendingValidation(textDocument: TextDocument): void {
+    const request = pendingValidationRequests[textDocument.uri]
+    if (request) {
+      request.dispose()
+      delete pendingValidationRequests[textDocument.uri]
+    }
+  }
 
-	function cleanPendingValidation(textDocument: TextDocument): void {
-		const request = pendingValidationRequests[textDocument.uri];
-		if (request) {
-			clearTimeout(request);
-			delete pendingValidationRequests[textDocument.uri];
-		}
-	}
+  function triggerValidation(textDocument: TextDocument): void {
+    cleanPendingValidation(textDocument)
+    pendingValidationRequests[textDocument.uri] = runtime.timer.setTimeout(
+      () => {
+        delete pendingValidationRequests[textDocument.uri]
+        validateTextDocument(textDocument)
+      },
+      validationDelayMs
+    )
+  }
 
-	function triggerValidation(textDocument: TextDocument): void {
-		cleanPendingValidation(textDocument);
-		pendingValidationRequests[textDocument.uri] = setTimeout(() => {
-			delete pendingValidationRequests[textDocument.uri];
-			validateTextDocument(textDocument);
-		}, validationDelayMs);
-	}
+  function validateTextDocument(textDocument: TextDocument): void {
+    const settingsPromise = getDocumentSettings(textDocument)
+    Promise.all([settingsPromise, dataProvidersReady]).then(
+      async ([settings]) => {
+        const stylesheet = stylesheets.get(textDocument)
+        const diagnostics = getLanguageService(textDocument).doValidation(
+          textDocument,
+          stylesheet,
+          settings
+        )
+        // Send the computed diagnostics to VSCode.
+        connection.sendDiagnostics({ uri: textDocument.uri, diagnostics })
+      },
+      (e) => {
+        connection.console.error(
+          formatError(`Error while validating ${textDocument.uri}`, e)
+        )
+      }
+    )
+  }
 
-	function validateTextDocument(textDocument: TextDocument): void {
-		const settingsPromise = getDocumentSettings(textDocument);
-		Promise.all([settingsPromise, dataProvidersReady]).then(async ([settings]) => {
-			const stylesheet = stylesheets.get(textDocument);
-			const diagnostics = getLanguageService(textDocument).doValidation(textDocument, stylesheet, settings);
-			// Send the computed diagnostics to VSCode.
-			connection.sendDiagnostics({ uri: textDocument.uri, diagnostics });
-		}, e => {
-			connection.console.error(formatError(`Error while validating ${textDocument.uri}`, e));
-		});
-	}
+  function updateDataProviders(dataPaths: string[]) {
+    dataProvidersReady = fetchDataProviders(dataPaths, requestService).then(
+      (customDataProviders) => {
+        for (const lang in languageServices) {
+          languageServices[lang].setDataProviders(true, customDataProviders)
+        }
+      }
+    )
+  }
 
+  connection.onCompletion((textDocumentPosition, token) => {
+    return runSafeAsync(
+      runtime,
+      async () => {
+        const document = documents.get(textDocumentPosition.textDocument.uri)
+        if (document) {
+          const [settings] = await Promise.all([
+            getDocumentSettings(document),
+            dataProvidersReady
+          ])
+          const styleSheet = stylesheets.get(document)
+          const documentContext = getDocumentContext(
+            document.uri,
+            workspaceFolders
+          )
+          return getLanguageService(document).doComplete2(
+            document,
+            textDocumentPosition.position,
+            styleSheet,
+            documentContext,
+            settings?.completion
+          )
+        }
+        return null
+      },
+      null,
+      `Error while computing completions for ${textDocumentPosition.textDocument.uri}`,
+      token
+    )
+  })
 
-	function updateDataProviders(dataPaths: string[]) {
-		dataProvidersReady = fetchDataProviders(dataPaths, requestService).then(customDataProviders => {
-			for (const lang in languageServices) {
-				languageServices[lang].setDataProviders(true, customDataProviders);
-			}
-		});
-	}
+  connection.onHover((textDocumentPosition, token) => {
+    return runSafeAsync(
+      runtime,
+      async () => {
+        const document = documents.get(textDocumentPosition.textDocument.uri)
+        if (document) {
+          const [settings] = await Promise.all([
+            getDocumentSettings(document),
+            dataProvidersReady
+          ])
+          const styleSheet = stylesheets.get(document)
+          return getLanguageService(document).doHover(
+            document,
+            textDocumentPosition.position,
+            styleSheet,
+            settings?.hover
+          )
+        }
+        return null
+      },
+      null,
+      `Error while computing hover for ${textDocumentPosition.textDocument.uri}`,
+      token
+    )
+  })
 
-	connection.onCompletion((textDocumentPosition, token) => {
-		return runSafeAsync(async () => {
-			const document = documents.get(textDocumentPosition.textDocument.uri);
-			if (document) {
-				await dataProvidersReady;
-				const styleSheet = stylesheets.get(document);
-				const documentContext = getDocumentContext(document.uri, workspaceFolders);
-				return getLanguageService(document).doComplete2(document, textDocumentPosition.position, styleSheet, documentContext);
-			}
-			return null;
-		}, null, `Error while computing completions for ${textDocumentPosition.textDocument.uri}`, token);
-	});
+  connection.onDocumentSymbol((documentSymbolParams, token) => {
+    return runSafeAsync(
+      runtime,
+      async () => {
+        const document = documents.get(documentSymbolParams.textDocument.uri)
+        if (document) {
+          await dataProvidersReady
+          const stylesheet = stylesheets.get(document)
+          return getLanguageService(document).findDocumentSymbols(
+            document,
+            stylesheet
+          )
+        }
+        return []
+      },
+      [],
+      `Error while computing document symbols for ${documentSymbolParams.textDocument.uri}`,
+      token
+    )
+  })
 
-	connection.onHover((textDocumentPosition, token) => {
-		return runSafeAsync(async () => {
-			const document = documents.get(textDocumentPosition.textDocument.uri);
-			if (document) {
-				await dataProvidersReady;
-				const styleSheet = stylesheets.get(document);
-				return getLanguageService(document).doHover(document, textDocumentPosition.position, styleSheet);
-			}
-			return null;
-		}, null, `Error while computing hover for ${textDocumentPosition.textDocument.uri}`, token);
-	});
+  connection.onDefinition((documentDefinitionParams, token) => {
+    return runSafeAsync(
+      runtime,
+      async () => {
+        const document = documents.get(
+          documentDefinitionParams.textDocument.uri
+        )
+        if (document) {
+          await dataProvidersReady
+          const stylesheet = stylesheets.get(document)
+          return getLanguageService(document).findDefinition(
+            document,
+            documentDefinitionParams.position,
+            stylesheet
+          )
+        }
+        return null
+      },
+      null,
+      `Error while computing definitions for ${documentDefinitionParams.textDocument.uri}`,
+      token
+    )
+  })
 
-	connection.onDocumentSymbol((documentSymbolParams, token) => {
-		return runSafeAsync(async () => {
-			const document = documents.get(documentSymbolParams.textDocument.uri);
-			if (document) {
-				await dataProvidersReady;
-				const stylesheet = stylesheets.get(document);
-				return getLanguageService(document).findDocumentSymbols(document, stylesheet);
-			}
-			return [];
-		}, [], `Error while computing document symbols for ${documentSymbolParams.textDocument.uri}`, token);
-	});
+  connection.onDocumentHighlight((documentHighlightParams, token) => {
+    return runSafeAsync(
+      runtime,
+      async () => {
+        const document = documents.get(documentHighlightParams.textDocument.uri)
+        if (document) {
+          await dataProvidersReady
+          const stylesheet = stylesheets.get(document)
+          return getLanguageService(document).findDocumentHighlights(
+            document,
+            documentHighlightParams.position,
+            stylesheet
+          )
+        }
+        return []
+      },
+      [],
+      `Error while computing document highlights for ${documentHighlightParams.textDocument.uri}`,
+      token
+    )
+  })
 
-	connection.onDefinition((documentDefinitionParams, token) => {
-		return runSafeAsync(async () => {
-			const document = documents.get(documentDefinitionParams.textDocument.uri);
-			if (document) {
-				await dataProvidersReady;
-				const stylesheet = stylesheets.get(document);
-				return getLanguageService(document).findDefinition(document, documentDefinitionParams.position, stylesheet);
-			}
-			return null;
-		}, null, `Error while computing definitions for ${documentDefinitionParams.textDocument.uri}`, token);
-	});
+  connection.onDocumentLinks(async (documentLinkParams, token) => {
+    return runSafeAsync(
+      runtime,
+      async () => {
+        const document = documents.get(documentLinkParams.textDocument.uri)
+        if (document) {
+          await dataProvidersReady
+          const documentContext = getDocumentContext(
+            document.uri,
+            workspaceFolders
+          )
+          const stylesheet = stylesheets.get(document)
+          return getLanguageService(document).findDocumentLinks2(
+            document,
+            stylesheet,
+            documentContext
+          )
+        }
+        return []
+      },
+      [],
+      `Error while computing document links for ${documentLinkParams.textDocument.uri}`,
+      token
+    )
+  })
 
-	connection.onDocumentHighlight((documentHighlightParams, token) => {
-		return runSafeAsync(async () => {
-			const document = documents.get(documentHighlightParams.textDocument.uri);
-			if (document) {
-				await dataProvidersReady;
-				const stylesheet = stylesheets.get(document);
-				return getLanguageService(document).findDocumentHighlights(document, documentHighlightParams.position, stylesheet);
-			}
-			return [];
-		}, [], `Error while computing document highlights for ${documentHighlightParams.textDocument.uri}`, token);
-	});
+  connection.onReferences((referenceParams, token) => {
+    return runSafeAsync(
+      runtime,
+      async () => {
+        const document = documents.get(referenceParams.textDocument.uri)
+        if (document) {
+          await dataProvidersReady
+          const stylesheet = stylesheets.get(document)
+          return getLanguageService(document).findReferences(
+            document,
+            referenceParams.position,
+            stylesheet
+          )
+        }
+        return []
+      },
+      [],
+      `Error while computing references for ${referenceParams.textDocument.uri}`,
+      token
+    )
+  })
 
+  connection.onCodeAction((codeActionParams, token) => {
+    return runSafeAsync(
+      runtime,
+      async () => {
+        const document = documents.get(codeActionParams.textDocument.uri)
+        if (document) {
+          await dataProvidersReady
+          const stylesheet = stylesheets.get(document)
+          return getLanguageService(document).doCodeActions(
+            document,
+            codeActionParams.range,
+            codeActionParams.context,
+            stylesheet
+          )
+        }
+        return []
+      },
+      [],
+      `Error while computing code actions for ${codeActionParams.textDocument.uri}`,
+      token
+    )
+  })
 
-	connection.onDocumentLinks(async (documentLinkParams, token) => {
-		return runSafeAsync(async () => {
-			const document = documents.get(documentLinkParams.textDocument.uri);
-			if (document) {
-				await dataProvidersReady;
-				const documentContext = getDocumentContext(document.uri, workspaceFolders);
-				const stylesheet = stylesheets.get(document);
-				return getLanguageService(document).findDocumentLinks2(document, stylesheet, documentContext);
-			}
-			return [];
-		}, [], `Error while computing document links for ${documentLinkParams.textDocument.uri}`, token);
-	});
+  connection.onDocumentColor((params, token) => {
+    return runSafeAsync(
+      runtime,
+      async () => {
+        const document = documents.get(params.textDocument.uri)
+        if (document) {
+          await dataProvidersReady
+          const stylesheet = stylesheets.get(document)
+          return getLanguageService(document).findDocumentColors(
+            document,
+            stylesheet
+          )
+        }
+        return []
+      },
+      [],
+      `Error while computing document colors for ${params.textDocument.uri}`,
+      token
+    )
+  })
 
+  connection.onColorPresentation((params, token) => {
+    return runSafeAsync(
+      runtime,
+      async () => {
+        const document = documents.get(params.textDocument.uri)
+        if (document) {
+          await dataProvidersReady
+          const stylesheet = stylesheets.get(document)
+          return getLanguageService(document).getColorPresentations(
+            document,
+            stylesheet,
+            params.color,
+            params.range
+          )
+        }
+        return []
+      },
+      [],
+      `Error while computing color presentations for ${params.textDocument.uri}`,
+      token
+    )
+  })
 
-	connection.onReferences((referenceParams, token) => {
-		return runSafeAsync(async () => {
-			const document = documents.get(referenceParams.textDocument.uri);
-			if (document) {
-				await dataProvidersReady;
-				const stylesheet = stylesheets.get(document);
-				return getLanguageService(document).findReferences(document, referenceParams.position, stylesheet);
-			}
-			return [];
-		}, [], `Error while computing references for ${referenceParams.textDocument.uri}`, token);
-	});
+  connection.onRenameRequest((renameParameters, token) => {
+    return runSafeAsync(
+      runtime,
+      async () => {
+        const document = documents.get(renameParameters.textDocument.uri)
+        if (document) {
+          await dataProvidersReady
+          const stylesheet = stylesheets.get(document)
+          return getLanguageService(document).doRename(
+            document,
+            renameParameters.position,
+            renameParameters.newName,
+            stylesheet
+          )
+        }
+        return null
+      },
+      null,
+      `Error while computing renames for ${renameParameters.textDocument.uri}`,
+      token
+    )
+  })
 
-	connection.onCodeAction((codeActionParams, token) => {
-		return runSafeAsync(async () => {
-			const document = documents.get(codeActionParams.textDocument.uri);
-			if (document) {
-				await dataProvidersReady;
-				const stylesheet = stylesheets.get(document);
-				return getLanguageService(document).doCodeActions(document, codeActionParams.range, codeActionParams.context, stylesheet);
-			}
-			return [];
-		}, [], `Error while computing code actions for ${codeActionParams.textDocument.uri}`, token);
-	});
+  connection.onFoldingRanges((params, token) => {
+    return runSafeAsync(
+      runtime,
+      async () => {
+        const document = documents.get(params.textDocument.uri)
+        if (document) {
+          await dataProvidersReady
+          return getLanguageService(document).getFoldingRanges(document, {
+            rangeLimit: foldingRangeLimit
+          })
+        }
+        return null
+      },
+      null,
+      `Error while computing folding ranges for ${params.textDocument.uri}`,
+      token
+    )
+  })
 
-	connection.onDocumentColor((params, token) => {
-		return runSafeAsync(async () => {
-			const document = documents.get(params.textDocument.uri);
-			if (document) {
-				await dataProvidersReady;
-				const stylesheet = stylesheets.get(document);
-				return getLanguageService(document).findDocumentColors(document, stylesheet);
-			}
-			return [];
-		}, [], `Error while computing document colors for ${params.textDocument.uri}`, token);
-	});
+  connection.onSelectionRanges((params, token) => {
+    return runSafeAsync(
+      runtime,
+      async () => {
+        const document = documents.get(params.textDocument.uri)
+        const positions: Position[] = params.positions
 
-	connection.onColorPresentation((params, token) => {
-		return runSafeAsync(async () => {
-			const document = documents.get(params.textDocument.uri);
-			if (document) {
-				await dataProvidersReady;
-				const stylesheet = stylesheets.get(document);
-				return getLanguageService(document).getColorPresentations(document, stylesheet, params.color, params.range);
-			}
-			return [];
-		}, [], `Error while computing color presentations for ${params.textDocument.uri}`, token);
-	});
+        if (document) {
+          await dataProvidersReady
+          const stylesheet = stylesheets.get(document)
+          return getLanguageService(document).getSelectionRanges(
+            document,
+            positions,
+            stylesheet
+          )
+        }
+        return []
+      },
+      [],
+      `Error while computing selection ranges for ${params.textDocument.uri}`,
+      token
+    )
+  })
 
-	connection.onRenameRequest((renameParameters, token) => {
-		return runSafeAsync(async () => {
-			const document = documents.get(renameParameters.textDocument.uri);
-			if (document) {
-				await dataProvidersReady;
-				const stylesheet = stylesheets.get(document);
-				return getLanguageService(document).doRename(document, renameParameters.position, renameParameters.newName, stylesheet);
-			}
-			return null;
-		}, null, `Error while computing renames for ${renameParameters.textDocument.uri}`, token);
-	});
+  connection.onNotification(
+    CustomDataChangedNotification.type,
+    updateDataProviders
+  )
 
-	connection.onFoldingRanges((params, token) => {
-		return runSafeAsync(async () => {
-			const document = documents.get(params.textDocument.uri);
-			if (document) {
-				await dataProvidersReady;
-				return getLanguageService(document).getFoldingRanges(document, { rangeLimit: foldingRangeLimit });
-			}
-			return null;
-		}, null, `Error while computing folding ranges for ${params.textDocument.uri}`, token);
-	});
-
-	connection.onSelectionRanges((params, token) => {
-		return runSafeAsync(async () => {
-			const document = documents.get(params.textDocument.uri);
-			const positions: Position[] = params.positions;
-
-			if (document) {
-				await dataProvidersReady;
-				const stylesheet = stylesheets.get(document);
-				return getLanguageService(document).getSelectionRanges(document, positions, stylesheet);
-			}
-			return [];
-		}, [], `Error while computing selection ranges for ${params.textDocument.uri}`, token);
-	});
-
-	connection.onNotification(CustomDataChangedNotification.type, updateDataProviders);
-
-	// Listen on the connection
-	connection.listen();
-
+  // Listen on the connection
+  connection.listen()
 }
-
-

--- a/server/customData.ts
+++ b/server/customData.ts
@@ -3,36 +3,42 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ICSSDataProvider, newCSSDataProvider } from 'vscode-css-languageservice';
-import { RequestService } from './requests';
+import {
+  ICSSDataProvider,
+  newCSSDataProvider
+} from 'vscode-css-languageservice'
+import { RequestService } from './requests'
 
-export function fetchDataProviders(dataPaths: string[], requestService: RequestService): Promise<ICSSDataProvider[]> {
-	const providers = dataPaths.map(async p => {
-		try {
-			const content = await requestService.getContent(p);
-			return parseCSSData(content);
-		} catch (e) {
-			return newCSSDataProvider({ version: 1 });
-		}
-	});
+export function fetchDataProviders(
+  dataPaths: string[],
+  requestService: RequestService
+): Promise<ICSSDataProvider[]> {
+  const providers = dataPaths.map(async (p) => {
+    try {
+      const content = await requestService.getContent(p)
+      return parseCSSData(content)
+    } catch (e) {
+      return newCSSDataProvider({ version: 1 })
+    }
+  })
 
-	return Promise.all(providers);
+  return Promise.all(providers)
 }
 
 function parseCSSData(source: string): ICSSDataProvider {
-	let rawData: any;
+  let rawData: any
 
-	try {
-		rawData = JSON.parse(source);
-	} catch (err) {
-		return newCSSDataProvider({ version: 1 });
-	}
+  try {
+    rawData = JSON.parse(source)
+  } catch (err) {
+    return newCSSDataProvider({ version: 1 })
+  }
 
-	return newCSSDataProvider({
-		version: rawData.version || 1,
-		properties: rawData.properties || [],
-		atDirectives: rawData.atDirectives || [],
-		pseudoClasses: rawData.pseudoClasses || [],
-		pseudoElements: rawData.pseudoElements || []
-	});
+  return newCSSDataProvider({
+    version: rawData.version || 1,
+    properties: rawData.properties || [],
+    atDirectives: rawData.atDirectives || [],
+    pseudoClasses: rawData.pseudoClasses || [],
+    pseudoElements: rawData.pseudoElements || []
+  })
 }

--- a/server/languageModelCache.ts
+++ b/server/languageModelCache.ts
@@ -3,80 +3,99 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { TextDocument } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-css-languageservice'
 
 export interface LanguageModelCache<T> {
-	get(document: TextDocument): T;
-	onDocumentRemoved(document: TextDocument): void;
-	dispose(): void;
+  get(document: TextDocument): T
+  onDocumentRemoved(document: TextDocument): void
+  dispose(): void
 }
 
-export function getLanguageModelCache<T>(maxEntries: number, cleanupIntervalTimeInSec: number, parse: (document: TextDocument) => T): LanguageModelCache<T> {
-	let languageModels: { [uri: string]: { version: number, languageId: string, cTime: number, languageModel: T } } = {};
-	let nModels = 0;
+export function getLanguageModelCache<T>(
+  maxEntries: number,
+  cleanupIntervalTimeInSec: number,
+  parse: (document: TextDocument) => T
+): LanguageModelCache<T> {
+  let languageModels: {
+    [uri: string]: {
+      version: number
+      languageId: string
+      cTime: number
+      languageModel: T
+    }
+  } = {}
+  let nModels = 0
 
-	let cleanupInterval: NodeJS.Timer | undefined = undefined;
-	if (cleanupIntervalTimeInSec > 0) {
-		cleanupInterval = setInterval(() => {
-			let cutoffTime = Date.now() - cleanupIntervalTimeInSec * 1000;
-			let uris = Object.keys(languageModels);
-			for (let uri of uris) {
-				let languageModelInfo = languageModels[uri];
-				if (languageModelInfo.cTime < cutoffTime) {
-					delete languageModels[uri];
-					nModels--;
-				}
-			}
-		}, cleanupIntervalTimeInSec * 1000);
-	}
+  let cleanupInterval: NodeJS.Timer | undefined = undefined
+  if (cleanupIntervalTimeInSec > 0) {
+    cleanupInterval = setInterval(() => {
+      let cutoffTime = Date.now() - cleanupIntervalTimeInSec * 1000
+      let uris = Object.keys(languageModels)
+      for (let uri of uris) {
+        let languageModelInfo = languageModels[uri]
+        if (languageModelInfo.cTime < cutoffTime) {
+          delete languageModels[uri]
+          nModels--
+        }
+      }
+    }, cleanupIntervalTimeInSec * 1000)
+  }
 
-	return {
-		get(document: TextDocument): T {
-			let version = document.version;
-			let languageId = document.languageId;
-			let languageModelInfo = languageModels[document.uri];
-			if (languageModelInfo && languageModelInfo.version === version && languageModelInfo.languageId === languageId) {
-				languageModelInfo.cTime = Date.now();
-				return languageModelInfo.languageModel;
-			}
-			let languageModel = parse(document);
-			languageModels[document.uri] = { languageModel, version, languageId, cTime: Date.now() };
-			if (!languageModelInfo) {
-				nModels++;
-			}
+  return {
+    get(document: TextDocument): T {
+      let version = document.version
+      let languageId = document.languageId
+      let languageModelInfo = languageModels[document.uri]
+      if (
+        languageModelInfo &&
+        languageModelInfo.version === version &&
+        languageModelInfo.languageId === languageId
+      ) {
+        languageModelInfo.cTime = Date.now()
+        return languageModelInfo.languageModel
+      }
+      let languageModel = parse(document)
+      languageModels[document.uri] = {
+        languageModel,
+        version,
+        languageId,
+        cTime: Date.now()
+      }
+      if (!languageModelInfo) {
+        nModels++
+      }
 
-			if (nModels === maxEntries) {
-				let oldestTime = Number.MAX_VALUE;
-				let oldestUri = null;
-				for (let uri in languageModels) {
-					let languageModelInfo = languageModels[uri];
-					if (languageModelInfo.cTime < oldestTime) {
-						oldestUri = uri;
-						oldestTime = languageModelInfo.cTime;
-					}
-				}
-				if (oldestUri) {
-					delete languageModels[oldestUri];
-					nModels--;
-				}
-			}
-			return languageModel;
-
-		},
-		onDocumentRemoved(document: TextDocument) {
-			let uri = document.uri;
-			if (languageModels[uri]) {
-				delete languageModels[uri];
-				nModels--;
-			}
-		},
-		dispose() {
-			if (typeof cleanupInterval !== 'undefined') {
-				clearInterval(cleanupInterval);
-				cleanupInterval = undefined;
-				languageModels = {};
-				nModels = 0;
-			}
-		}
-	};
+      if (nModels === maxEntries) {
+        let oldestTime = Number.MAX_VALUE
+        let oldestUri = null
+        for (let uri in languageModels) {
+          let languageModelInfo = languageModels[uri]
+          if (languageModelInfo.cTime < oldestTime) {
+            oldestUri = uri
+            oldestTime = languageModelInfo.cTime
+          }
+        }
+        if (oldestUri) {
+          delete languageModels[oldestUri]
+          nModels--
+        }
+      }
+      return languageModel
+    },
+    onDocumentRemoved(document: TextDocument) {
+      let uri = document.uri
+      if (languageModels[uri]) {
+        delete languageModels[uri]
+        nModels--
+      }
+    },
+    dispose() {
+      if (typeof cleanupInterval !== 'undefined') {
+        clearInterval(cleanupInterval)
+        cleanupInterval = undefined
+        languageModels = {}
+        nModels = 0
+      }
+    }
+  }
 }

--- a/server/node/cssServerMain.ts
+++ b/server/node/cssServerMain.ts
@@ -3,19 +3,44 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { createConnection, Connection } from 'vscode-languageserver/node';
-import { formatError } from '../utils/runner';
-import { startServer } from '../cssServer';
-import { getNodeFSRequestService } from './nodeFs';
+import {
+  createConnection,
+  Connection,
+  Disposable
+} from 'vscode-languageserver/node'
+import { formatError } from '../utils/runner'
+import { RuntimeEnvironment, startServer } from '../cssServer'
+import { getNodeFSRequestService } from './nodeFs'
 
 // Create a connection for the server.
-const connection: Connection = createConnection();
+const connection: Connection = createConnection()
 
-console.log = connection.console.log.bind(connection.console);
-console.error = connection.console.error.bind(connection.console);
+console.log = connection.console.log.bind(connection.console)
+console.error = connection.console.error.bind(connection.console)
 
 process.on('unhandledRejection', (e: any) => {
-	connection.console.error(formatError(`Unhandled exception`, e));
-});
+  connection.console.error(formatError(`Unhandled exception`, e))
+})
 
-startServer(connection, { file: getNodeFSRequestService() });
+const runtime: RuntimeEnvironment = {
+  timer: {
+    setImmediate(
+      callback: (...args: any[]) => void,
+      ...args: any[]
+    ): Disposable {
+      const handle = setImmediate(callback, ...args)
+      return { dispose: () => clearImmediate(handle) }
+    },
+    setTimeout(
+      callback: (...args: any[]) => void,
+      ms: number,
+      ...args: any[]
+    ): Disposable {
+      const handle = setTimeout(callback, ms, ...args)
+      return { dispose: () => clearTimeout(handle) }
+    }
+  },
+  file: getNodeFSRequestService()
+}
+
+startServer(connection, runtime)

--- a/server/node/nodeFs.ts
+++ b/server/node/nodeFs.ts
@@ -3,85 +3,91 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { RequestService, getScheme } from '../requests';
-import { URI as Uri } from 'vscode-uri';
+import { RequestService } from '../requests'
+import { URI as Uri } from 'vscode-uri'
 
-import * as fs from 'fs';
-import { FileType } from 'vscode-css-languageservice';
+import * as fs from 'fs'
+import { FileType } from 'vscode-css-languageservice'
 
 export function getNodeFSRequestService(): RequestService {
-	function ensureFileUri(location: string) {
-		if (getScheme(location) !== 'file') {
-			throw new Error('fileRequestService can only handle file URLs');
-		}
-	}
-	return {
-		getContent(location: string, encoding?: string) {
-			ensureFileUri(location);
-			return new Promise((c, e) => {
-				const uri = Uri.parse(location);
-				fs.readFile(uri.fsPath, encoding, (err, buf) => {
-					if (err) {
-						return e(err);
-					}
-					c(buf.toString());
+  function ensureFileUri(location: string) {
+    if (!location.startsWith('file://')) {
+      throw new Error('fileRequestService can only handle file URLs')
+    }
+  }
+  return {
+    getContent(location: string, encoding?: string) {
+      ensureFileUri(location)
+      return new Promise((c, e) => {
+        const uri = Uri.parse(location)
+        fs.readFile(uri.fsPath, encoding, (err, buf) => {
+          if (err) {
+            return e(err)
+          }
+          c(buf.toString())
+        })
+      })
+    },
+    stat(location: string) {
+      ensureFileUri(location)
+      return new Promise((c, e) => {
+        const uri = Uri.parse(location)
+        fs.stat(uri.fsPath, (err, stats) => {
+          if (err) {
+            if (err.code === 'ENOENT') {
+              return c({
+                type: FileType.Unknown,
+                ctime: -1,
+                mtime: -1,
+                size: -1
+              })
+            } else {
+              return e(err)
+            }
+          }
 
-				});
-			});
-		},
-		stat(location: string) {
-			ensureFileUri(location);
-			return new Promise((c, e) => {
-				const uri = Uri.parse(location);
-				fs.stat(uri.fsPath, (err, stats) => {
-					if (err) {
-						if (err.code === 'ENOENT') {
-							return c({ type: FileType.Unknown, ctime: -1, mtime: -1, size: -1 });
-						} else {
-							return e(err);
-						}
-					}
+          let type = FileType.Unknown
+          if (stats.isFile()) {
+            type = FileType.File
+          } else if (stats.isDirectory()) {
+            type = FileType.Directory
+          } else if (stats.isSymbolicLink()) {
+            type = FileType.SymbolicLink
+          }
 
-					let type = FileType.Unknown;
-					if (stats.isFile()) {
-						type = FileType.File;
-					} else if (stats.isDirectory()) {
-						type = FileType.Directory;
-					} else if (stats.isSymbolicLink()) {
-						type = FileType.SymbolicLink;
-					}
+          c({
+            type,
+            ctime: stats.ctime.getTime(),
+            mtime: stats.mtime.getTime(),
+            size: stats.size
+          })
+        })
+      })
+    },
+    readDirectory(location: string) {
+      ensureFileUri(location)
+      return new Promise((c, e) => {
+        const path = Uri.parse(location).fsPath
 
-					c({
-						type,
-						ctime: stats.ctime.getTime(),
-						mtime: stats.mtime.getTime(),
-						size: stats.size
-					});
-				});
-			});
-		},
-		readDirectory(location: string) {
-			ensureFileUri(location);
-			return new Promise((c, e) => {
-				const path = Uri.parse(location).fsPath;
-
-				fs.readdir(path, { withFileTypes: true }, (err, children) => {
-					if (err) {
-						return e(err);
-					}
-					c(children.map(stat => {
-						if (stat.isSymbolicLink()) {
-							return [stat.name, FileType.SymbolicLink];
-						} else if (stat.isDirectory()) {
-							return [stat.name, FileType.Directory];
-						} else if (stat.isFile()) {
-							return [stat.name, FileType.File];
-						} else {
-							return [stat.name, FileType.Unknown];
-						}
-					}));
-				});
-			});
-		}
-	};
+        fs.readdir(path, { withFileTypes: true }, (err, children) => {
+          if (err) {
+            return e(err)
+          }
+          c(
+            children.map((stat) => {
+              if (stat.isSymbolicLink()) {
+                return [stat.name, FileType.SymbolicLink]
+              } else if (stat.isDirectory()) {
+                return [stat.name, FileType.Directory]
+              } else if (stat.isFile()) {
+                return [stat.name, FileType.File]
+              } else {
+                return [stat.name, FileType.Unknown]
+              }
+            })
+          )
+        })
+      })
+    }
+  }
 }

--- a/server/requests.ts
+++ b/server/requests.ts
@@ -3,175 +3,117 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { URI } from 'vscode-uri';
-import { RequestType, Connection } from 'vscode-languageserver';
-import { RuntimeEnvironment } from './cssServer';
+import { RequestType, Connection } from 'vscode-languageserver'
+import { RuntimeEnvironment } from './cssServer'
 
 export namespace FsContentRequest {
-	export const type: RequestType<{ uri: string; encoding?: string; }, string, any, any> = new RequestType('fs/content');
+  export const type: RequestType<
+    { uri: string; encoding?: string },
+    string,
+    any
+  > = new RequestType('fs/content')
 }
 export namespace FsStatRequest {
-	export const type: RequestType<string, FileStat, any, any> = new RequestType('fs/stat');
+  export const type: RequestType<string, FileStat, any> = new RequestType(
+    'fs/stat'
+  )
 }
 
 export namespace FsReadDirRequest {
-	export const type: RequestType<string, [string, FileType][], any, any> = new RequestType('fs/readDir');
+  export const type: RequestType<string, [string, FileType][], any> =
+    new RequestType('fs/readDir')
 }
 
 export enum FileType {
-	/**
-	 * The file type is unknown.
-	 */
-	Unknown = 0,
-	/**
-	 * A regular file.
-	 */
-	File = 1,
-	/**
-	 * A directory.
-	 */
-	Directory = 2,
-	/**
-	 * A symbolic link to a file.
-	 */
-	SymbolicLink = 64
+  /**
+   * The file type is unknown.
+   */
+  Unknown = 0,
+  /**
+   * A regular file.
+   */
+  File = 1,
+  /**
+   * A directory.
+   */
+  Directory = 2,
+  /**
+   * A symbolic link to a file.
+   */
+  SymbolicLink = 64
 }
 export interface FileStat {
-	/**
-	 * The type of the file, e.g. is a regular file, a directory, or symbolic link
-	 * to a file.
-	 */
-	type: FileType;
-	/**
-	 * The creation timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC.
-	 */
-	ctime: number;
-	/**
-	 * The modification timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC.
-	 */
-	mtime: number;
-	/**
-	 * The size in bytes.
-	 */
-	size: number;
+  /**
+   * The type of the file, e.g. is a regular file, a directory, or symbolic link
+   * to a file.
+   */
+  type: FileType
+  /**
+   * The creation timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC.
+   */
+  ctime: number
+  /**
+   * The modification timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC.
+   */
+  mtime: number
+  /**
+   * The size in bytes.
+   */
+  size: number
 }
 
 export interface RequestService {
-	getContent(uri: string, encoding?: string): Promise<string>;
+  getContent(uri: string, encoding?: string): Promise<string>
 
-	stat(uri: string): Promise<FileStat>;
-	readDirectory(uri: string): Promise<[string, FileType][]>;
+  stat(uri: string): Promise<FileStat>
+  readDirectory(uri: string): Promise<[string, FileType][]>
 }
 
-
-export function getRequestService(handledSchemas: string[], connection: Connection, runtime: RuntimeEnvironment): RequestService {
-	const builtInHandlers: { [protocol: string]: RequestService | undefined } = {};
-	for (let protocol of handledSchemas) {
-		if (protocol === 'file') {
-			builtInHandlers[protocol] = runtime.file;
-		} else if (protocol === 'http' || protocol === 'https') {
-			builtInHandlers[protocol] = runtime.http;
-		}
-	}
-	return {
-		async stat(uri: string): Promise<FileStat> {
-			const handler = builtInHandlers[getScheme(uri)];
-			if (handler) {
-				return handler.stat(uri);
-			}
-			const res = await connection.sendRequest(FsStatRequest.type, uri.toString());
-			return res;
-		},
-		readDirectory(uri: string): Promise<[string, FileType][]> {
-			const handler = builtInHandlers[getScheme(uri)];
-			if (handler) {
-				return handler.readDirectory(uri);
-			}
-			return connection.sendRequest(FsReadDirRequest.type, uri.toString());
-		},
-		getContent(uri: string, encoding?: string): Promise<string> {
-			const handler = builtInHandlers[getScheme(uri)];
-			if (handler) {
-				return handler.getContent(uri, encoding);
-			}
-			return connection.sendRequest(FsContentRequest.type, { uri: uri.toString(), encoding });
-		}
-	};
+export function getRequestService(
+  handledSchemas: string[],
+  connection: Connection,
+  runtime: RuntimeEnvironment
+): RequestService {
+  const builtInHandlers: { [protocol: string]: RequestService | undefined } = {}
+  for (let protocol of handledSchemas) {
+    if (protocol === 'file') {
+      builtInHandlers[protocol] = runtime.file
+    } else if (protocol === 'http' || protocol === 'https') {
+      builtInHandlers[protocol] = runtime.http
+    }
+  }
+  return {
+    async stat(uri: string): Promise<FileStat> {
+      const handler = builtInHandlers[getScheme(uri)]
+      if (handler) {
+        return handler.stat(uri)
+      }
+      const res = await connection.sendRequest(
+        FsStatRequest.type,
+        uri.toString()
+      )
+      return res
+    },
+    readDirectory(uri: string): Promise<[string, FileType][]> {
+      const handler = builtInHandlers[getScheme(uri)]
+      if (handler) {
+        return handler.readDirectory(uri)
+      }
+      return connection.sendRequest(FsReadDirRequest.type, uri.toString())
+    },
+    getContent(uri: string, encoding?: string): Promise<string> {
+      const handler = builtInHandlers[getScheme(uri)]
+      if (handler) {
+        return handler.getContent(uri, encoding)
+      }
+      return connection.sendRequest(FsContentRequest.type, {
+        uri: uri.toString(),
+        encoding
+      })
+    }
+  }
 }
 
-export function getScheme(uri: string) {
-	return uri.substr(0, uri.indexOf(':'));
-}
-
-export function dirname(uri: string) {
-	const lastIndexOfSlash = uri.lastIndexOf('/');
-	return lastIndexOfSlash !== -1 ? uri.substr(0, lastIndexOfSlash) : '';
-}
-
-export function basename(uri: string) {
-	const lastIndexOfSlash = uri.lastIndexOf('/');
-	return uri.substr(lastIndexOfSlash + 1);
-}
-
-
-const Slash = '/'.charCodeAt(0);
-const Dot = '.'.charCodeAt(0);
-
-export function extname(uri: string) {
-	for (let i = uri.length - 1; i >= 0; i--) {
-		const ch = uri.charCodeAt(i);
-		if (ch === Dot) {
-			if (i > 0 && uri.charCodeAt(i - 1) !== Slash) {
-				return uri.substr(i);
-			} else {
-				break;
-			}
-		} else if (ch === Slash) {
-			break;
-		}
-	}
-	return '';
-}
-
-export function isAbsolutePath(path: string) {
-	return path.charCodeAt(0) === Slash;
-}
-
-export function resolvePath(uriString: string, path: string): string {
-	if (isAbsolutePath(path)) {
-		const uri = URI.parse(uriString);
-		const parts = path.split('/');
-		return uri.with({ path: normalizePath(parts) }).toString();
-	}
-	return joinPath(uriString, path);
-}
-
-export function normalizePath(parts: string[]): string {
-	const newParts: string[] = [];
-	for (const part of parts) {
-		if (part.length === 0 || part.length === 1 && part.charCodeAt(0) === Dot) {
-			// ignore
-		} else if (part.length === 2 && part.charCodeAt(0) === Dot && part.charCodeAt(1) === Dot) {
-			newParts.pop();
-		} else {
-			newParts.push(part);
-		}
-	}
-	if (parts.length > 1 && parts[parts.length - 1].length === 0) {
-		newParts.push('');
-	}
-	let res = newParts.join('/');
-	if (parts[0].length === 0) {
-		res = '/' + res;
-	}
-	return res;
-}
-
-export function joinPath(uriString: string, ...paths: string[]): string {
-	const uri = URI.parse(uriString);
-	const parts = uri.path.split('/');
-	for (let path of paths) {
-		parts.push(...path.split('/'));
-	}
-	return uri.with({ path: normalizePath(parts) }).toString();
+function getScheme(uri: string) {
+  return uri.substr(0, uri.indexOf(':'))
 }

--- a/server/utils/documentContext.ts
+++ b/server/utils/documentContext.ts
@@ -3,36 +3,39 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DocumentContext } from 'vscode-css-languageservice';
-import { endsWith, startsWith } from '../utils/strings';
-import { WorkspaceFolder } from 'vscode-languageserver';
-import { resolvePath } from '../requests';
+import { DocumentContext } from 'vscode-css-languageservice'
+import { endsWith, startsWith } from '../utils/strings'
+import { WorkspaceFolder } from 'vscode-languageserver'
+import { Utils, URI } from 'vscode-uri'
 
-export function getDocumentContext(documentUri: string, workspaceFolders: WorkspaceFolder[]): DocumentContext {
-	function getRootFolder(): string | undefined {
-		for (let folder of workspaceFolders) {
-			let folderURI = folder.uri;
-			if (!endsWith(folderURI, '/')) {
-				folderURI = folderURI + '/';
-			}
-			if (startsWith(documentUri, folderURI)) {
-				return folderURI;
-			}
-		}
-		return undefined;
-	}
+export function getDocumentContext(
+  documentUri: string,
+  workspaceFolders: WorkspaceFolder[]
+): DocumentContext {
+  function getRootFolder(): string | undefined {
+    for (let folder of workspaceFolders) {
+      let folderURI = folder.uri
+      if (!endsWith(folderURI, '/')) {
+        folderURI = folderURI + '/'
+      }
+      if (startsWith(documentUri, folderURI)) {
+        return folderURI
+      }
+    }
+    return undefined
+  }
 
-	return {
-		resolveReference: (ref: string, base = documentUri) => {
-			if (ref[0] === '/') { // resolve absolute path against the current workspace folder
-				let folderUri = getRootFolder();
-				if (folderUri) {
-					return folderUri + ref.substr(1);
-				}
-			}
-			base = base.substr(0, base.lastIndexOf('/') + 1);
-			return resolvePath(base, ref);
-		},
-	};
+  return {
+    resolveReference: (ref: string, base = documentUri) => {
+      if (ref[0] === '/') {
+        // resolve absolute path against the current workspace folder
+        let folderUri = getRootFolder()
+        if (folderUri) {
+          return folderUri + ref.substr(1)
+        }
+      }
+      base = base.substr(0, base.lastIndexOf('/') + 1)
+      return Utils.resolvePath(URI.parse(base), ref).toString()
+    }
+  }
 }
-

--- a/server/utils/runner.ts
+++ b/server/utils/runner.ts
@@ -3,41 +3,59 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ResponseError, ErrorCodes, CancellationToken } from 'vscode-languageserver';
+import {
+  ResponseError,
+  CancellationToken,
+  LSPErrorCodes
+} from 'vscode-languageserver'
+import { RuntimeEnvironment } from '../cssServer'
 
 export function formatError(message: string, err: any): string {
-	if (err instanceof Error) {
-		let error = <Error>err;
-		return `${message}: ${error.message}\n${error.stack}`;
-	} else if (typeof err === 'string') {
-		return `${message}: ${err}`;
-	} else if (err) {
-		return `${message}: ${err.toString()}`;
-	}
-	return message;
+  if (err instanceof Error) {
+    let error = <Error>err
+    return `${message}: ${error.message}\n${error.stack}`
+  } else if (typeof err === 'string') {
+    return `${message}: ${err}`
+  } else if (err) {
+    return `${message}: ${err.toString()}`
+  }
+  return message
 }
 
-export function runSafeAsync<T>(func: () => Thenable<T>, errorVal: T, errorMessage: string, token: CancellationToken): Thenable<T | ResponseError<any>> {
-	return new Promise<T | ResponseError<any>>((resolve) => {
-		setImmediate(() => {
-			if (token.isCancellationRequested) {
-				resolve(cancelValue());
-			}
-			return func().then(result => {
-				if (token.isCancellationRequested) {
-					resolve(cancelValue());
-					return;
-				} else {
-					resolve(result);
-				}
-			}, e => {
-				console.error(formatError(errorMessage, e));
-				resolve(errorVal);
-			});
-		});
-	});
+export function runSafeAsync<T>(
+  runtime: RuntimeEnvironment,
+  func: () => Thenable<T>,
+  errorVal: T,
+  errorMessage: string,
+  token: CancellationToken
+): Thenable<T | ResponseError<any>> {
+  return new Promise<T | ResponseError<any>>((resolve) => {
+    runtime.timer.setImmediate(() => {
+      if (token.isCancellationRequested) {
+        resolve(cancelValue())
+        return
+      }
+      return func().then(
+        (result) => {
+          if (token.isCancellationRequested) {
+            resolve(cancelValue())
+            return
+          } else {
+            resolve(result)
+          }
+        },
+        (e) => {
+          console.error(formatError(errorMessage, e))
+          resolve(errorVal)
+        }
+      )
+    })
+  })
 }
 
 function cancelValue<E>() {
-	return new ResponseError<E>(ErrorCodes.RequestCancelled, 'Request cancelled');
+  return new ResponseError<E>(
+    LSPErrorCodes.RequestCancelled,
+    'Request cancelled'
+  )
 }

--- a/server/utils/strings.ts
+++ b/server/utils/strings.ts
@@ -4,29 +4,29 @@
  *--------------------------------------------------------------------------------------------*/
 
 export function startsWith(haystack: string, needle: string): boolean {
-	if (haystack.length < needle.length) {
-		return false;
-	}
+  if (haystack.length < needle.length) {
+    return false
+  }
 
-	for (let i = 0; i < needle.length; i++) {
-		if (haystack[i] !== needle[i]) {
-			return false;
-		}
-	}
+  for (let i = 0; i < needle.length; i++) {
+    if (haystack[i] !== needle[i]) {
+      return false
+    }
+  }
 
-	return true;
+  return true
 }
 
 /**
  * Determines if haystack ends with needle.
  */
 export function endsWith(haystack: string, needle: string): boolean {
-	let diff = haystack.length - needle.length;
-	if (diff > 0) {
-		return haystack.lastIndexOf(needle) === diff;
-	} else if (diff === 0) {
-		return haystack === needle;
-	} else {
-		return false;
-	}
+  let diff = haystack.length - needle.length
+  if (diff > 0) {
+    return haystack.lastIndexOf(needle) === diff
+  } else if (diff === 0) {
+    return haystack === needle
+  } else {
+    return false
+  }
 }

--- a/src/customData.ts
+++ b/src/customData.ts
@@ -4,28 +4,38 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable, Emitter, extensions, Uri, workspace } from 'coc.nvim'
+import { Utils } from 'vscode-uri'
 import path from 'path'
 import { resolvePath } from './requests'
 
-export function getCustomDataSource(toDispose: Disposable[]): any {
+export function getCustomDataSource(toDispose: Disposable[]) {
   let pathsInWorkspace = getCustomDataPathsInAllWorkspaces()
   let pathsInExtensions = getCustomDataPathsFromAllExtensions()
 
   const onChange = new Emitter<void>()
 
-  toDispose.push(extensions.onDidActiveExtension(_ => {
-    const newPathsInExtensions = getCustomDataPathsFromAllExtensions()
-    if (newPathsInExtensions.length !== pathsInExtensions.length || !newPathsInExtensions.every((val, idx) => val === pathsInExtensions[idx])) {
-      pathsInExtensions = newPathsInExtensions
-      onChange.fire()
-    }
-  }))
-  toDispose.push(workspace.onDidChangeConfiguration(e => {
-    if (e.affectsConfiguration('css.customData')) {
-      pathsInWorkspace = getCustomDataPathsInAllWorkspaces()
-      onChange.fire()
-    }
-  }))
+  toDispose.push(
+    extensions.onDidActiveExtension((_) => {
+      const newPathsInExtensions = getCustomDataPathsFromAllExtensions()
+      if (
+        newPathsInExtensions.length !== pathsInExtensions.length ||
+        !newPathsInExtensions.every(
+          (val, idx) => val === pathsInExtensions[idx]
+        )
+      ) {
+        pathsInExtensions = newPathsInExtensions
+        onChange.fire()
+      }
+    })
+  )
+  toDispose.push(
+    workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration('css.customData')) {
+        pathsInWorkspace = getCustomDataPathsInAllWorkspaces()
+        onChange.fire()
+      }
+    })
+  )
 
   return {
     get uris() {
@@ -66,7 +76,6 @@ function getCustomDataPathsInAllWorkspaces(): string[] {
         collect(customDataInspect.globalValue, Uri.parse(folderUri))
       }
     }
-
   }
   return dataPaths
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1084,55 +1084,55 @@ v8-compile-cache@^2.1.0:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz#54bc3cdd43317bca91e35dcaf305b1a7237de745"
   integrity sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==
 
-vscode-css-languageservice@4.3.5:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/vscode-css-languageservice/-/vscode-css-languageservice-4.3.5.tgz#92f8817057dee7c381df2289aad539c7b553548a"
-  integrity sha512-g9Pjxt9T32jhY0nTOo7WRFm0As27IfdaAxcFa8c7Rml1ZqBn3XXbkExjzxY7sBWYm7I1Tp4dK6UHXHoUQHGwig==
+vscode-css-languageservice@5.1.8:
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/vscode-css-languageservice/-/vscode-css-languageservice-5.1.8.tgz#36cb389788ffc2d5e6630ffc84e55ee38f8a2338"
+  integrity sha512-Si1sMykS8U/p8LYgLGPCfZD1YFT0AtvUJQp9XJGw64DZWhtwYo28G2l64USLS9ge4ZPMZpwdpOK7PfbVKfgiiA==
   dependencies:
     vscode-languageserver-textdocument "^1.0.1"
-    vscode-languageserver-types "3.16.0-next.2"
+    vscode-languageserver-types "^3.16.0"
     vscode-nls "^5.0.0"
-    vscode-uri "^2.1.2"
+    vscode-uri "^3.0.2"
 
-vscode-jsonrpc@6.0.0-next.2:
-  version "6.0.0-next.2"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0-next.2.tgz#3d73f86d812304cb91b9fb1efee40ec60b09ed7f"
-  integrity sha512-dKQXRYNUY6BHALQJBJlyZyv9oWlYpbJ2vVoQNNVNPLAYQ3hzNp4zy+iSo7zGx1BPXByArJQDWTKLQh8dz3dnNw==
+vscode-jsonrpc@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz#108bdb09b4400705176b957ceca9e0880e9b6d4e"
+  integrity sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==
 
-vscode-languageserver-protocol@3.16.0-next.4:
-  version "3.16.0-next.4"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0-next.4.tgz#8f8b1b831d4dfd9b26aa1ba3d2a32c427a91c99f"
-  integrity sha512-6GmPUp2MhJy2H1CTWp2B40Pa9BeC9glrXWmQWVG6A/0V9UbcAjVC9m56znm2GL32iyLDIprTBe8gBvvvcjbpaQ==
+vscode-languageserver-protocol@3.16.0:
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz#34135b61a9091db972188a07d337406a3cdbe821"
+  integrity sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==
   dependencies:
-    vscode-jsonrpc "6.0.0-next.2"
-    vscode-languageserver-types "3.16.0-next.2"
+    vscode-jsonrpc "6.0.0"
+    vscode-languageserver-types "3.16.0"
 
 vscode-languageserver-textdocument@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz#178168e87efad6171b372add1dea34f53e5d330f"
   integrity sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA==
 
-vscode-languageserver-types@3.16.0-next.2:
-  version "3.16.0-next.2"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.2.tgz#940bd15c992295a65eae8ab6b8568a1e8daa3083"
-  integrity sha512-QjXB7CKIfFzKbiCJC4OWC8xUncLsxo19FzGVp/ADFvvi87PlmBSCAtZI5xwGjF5qE0xkLf0jjKUn3DzmpDP52Q==
+vscode-languageserver-types@3.16.0, vscode-languageserver-types@^3.16.0:
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz#ecf393fc121ec6974b2da3efb3155644c514e247"
+  integrity sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==
 
-vscode-languageserver@7.0.0-next.3:
-  version "7.0.0-next.3"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-7.0.0-next.3.tgz#3833bd09259a4a085baeba90783f1e4d06d81095"
-  integrity sha512-qSt8eb546iFuoFIN+9MPl4Avru6Iz2/JP0UmS/3djf40ICa31Np/yJ7anX2j0Az5rCzb0fak8oeKwDioGeVOYg==
+vscode-languageserver@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz#49b068c87cfcca93a356969d20f5d9bdd501c6b0"
+  integrity sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==
   dependencies:
-    vscode-languageserver-protocol "3.16.0-next.4"
+    vscode-languageserver-protocol "3.16.0"
 
 vscode-nls@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-5.0.0.tgz#99f0da0bd9ea7cda44e565a74c54b1f2bc257840"
   integrity sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA==
 
-vscode-uri@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-2.1.2.tgz#c8d40de93eb57af31f3c715dd650e2ca2c096f1c"
-  integrity sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==
+vscode-uri@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.2.tgz#ecfd1d066cb8ef4c3a208decdbab9a8c23d055d0"
+  integrity sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA==
 
 watchpack@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description

The `vscode-css-languageservice` currently used by `coc-css` is very old.

There are some features of the "LS" that have been fixed and adjusted in the latest version.

I have upgraded the `vscode-css-languageservice`. Also added and adjusted configuration options.

## Summary

- upgrade `vscode-css-languageservice` from "v4.3.5" to "v5.1.8"
- updated `server/*.ts` with reference to [css-language-features](https://github.com/microsoft/vscode/tree/main/extensions/css-language-features)
- client (`src/*.ts`) side has been updated with only minimal adjustments
- add and adjust configuration options

## Misc

`wxss.*` and `{css,scss,less}.colorDecorators.enable` configuration options do not exist in VSCode, so I thought about deleting them, but at this point I'm leaving them in just in case.